### PR TITLE
[JAVAVSCODE-22] Added support for using different jdk in each workspace and deprecated jdk.userdir configuration

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -85,7 +85,7 @@
 					],
 					"default": null,
 					"description": "Specifies JDK for the Oracle Visual Studio Code Extension",
-					"scope": "machine"
+					"scope": "machine-overridable"
 				},
 				"jdk.verbose": {
 					"type": "boolean",
@@ -103,7 +103,8 @@
 						"Share data between all workspaces (more effective)",
 						"Each workspace has its own data (more isolated)"
 					],
-					"default": "local"
+					"default": "local",
+					"deprecationMessage": "Separate userdir for each workspace is the default behaviour"
 				},
 				"jdk.revealActiveInProjects": {
 					"type": "boolean",


### PR DESCRIPTION
- Updated `jdk.jdkhome` to `machine-overridable` from `machine` so that different jdk binaries can be used in each workspace. Tested this configuration for remote SSH as well and it is working fine with it as well.
- Deprecated `jdk.userdir` configuration and default behaviour is now having separate `userdir` for each workspace and a global `userdir` if no workspace is open.