### PR TITLE
[JAVAVSCODE-71] Updated download.jdk command configuration to open JDK downloader window even if no folder is open in workspace

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -477,6 +477,9 @@
 					"command": "jdk.workspace.newproject"
 				},
 				{
+					"command": "jdk.download.jdk"
+				},
+				{
 					"command": "jdk.workspace.compile",
 					"when": "nbJdkReady"
 				},

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -444,6 +444,10 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             throw `Client ${c} doesn't support new project`;
         }
     }));
+    context.subscriptions.push(vscode.commands.registerCommand(COMMAND_PREFIX + ".download.jdk", async () => {
+        let c : LanguageClient = await client;
+        openJDKSelectionView(log);
+    }));
     context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.workspace.compile', () =>
         wrapCommandWithProgress(COMMAND_PREFIX + '.build.workspace', 'Compiling workspace...', log, true)
     ));
@@ -1107,7 +1111,6 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             }
         }));
         ctx.subscriptions.push(vscode.commands.registerCommand(COMMAND_PREFIX + ".select.editor.projects", () => revealActiveEditor()));
-        ctx.subscriptions.push(vscode.commands.registerCommand(COMMAND_PREFIX + ".download.jdk", () => openJDKSelectionView(log)));
 
         // attempt to reveal NOW:
         if (netbeansConfig.get("revealActiveInProjects")) {


### PR DESCRIPTION
Earlier only if some Java project or Java file was open in the workspace then only jdk downloader command could be executed from the command palette. So, it's configuration has been updated so that it can be executed even if workspace is empty.

Closes #71 