### PR TITLE
[JAVAVSCODE-16] Added option for running any Java project using context menu

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -467,6 +467,16 @@
 					"command": "jdk.java.goto.super.implementation",
 					"when": "nbJdkReady && editorLangId == java && editorTextFocus",
 					"group": "navigation@100"
+				},
+				{
+					"command": "jdk.project.run",
+					"when": "nbJdkReady && editorLangId == java && resourceExtname == .java",
+					"group": "javadebug@1"
+				},
+				{
+					"command": "jdk.project.debug",
+					"when": "nbJdkReady && editorLangId == java && resourceExtname == .java",
+					"group": "javadebug@2"
 				}
 			],
 			"explorer/context": [
@@ -474,6 +484,16 @@
 					"command": "jdk.workspace.new",
 					"when": "nbJdkReady && explorerResourceIsFolder",
 					"group": "navigation@3"
+				},
+				{
+					"command": "jdk.project.run",
+					"when": "nbJdkReady && resourceExtname == .java",
+					"group": "javadebug@1"
+				},
+				{
+					"command": "jdk.project.debug",
+					"when": "nbJdkReady && resourceExtname == .java",
+					"group": "javadebug@2"
 				}
 			],
 			"commandPalette": [


### PR DESCRIPTION
Added options in context menu for running and debugging any Java project. i.e. getting run java and debug java options when we right click on the java file, also we get these options when we right click on the code editor. 

Closes #16 

Image of how options look when we right click on a Java file in workspace

<img width="424" alt="image" src="https://github.com/oracle/javavscode/assets/55803675/5afaa618-c9c4-4621-979a-dce19a5fbbef">
