### PR TITLE
Build.md and .gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
-^netbeans/
+netbeans/
 .DS_STORE

--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@
 
 ## Prerequisities
 
-- JDK, version 11 or later
+- JDK, version 11 or later upto JDK 20
 - Ant, latest version
 - Maven, latest version
 - node.js, latest LTS (to build VSIX)
@@ -40,8 +40,20 @@ $ git clone https://github.com/apache/netbeans.git
 $ cd netbeans/
 $ git checkout f48f91e6c197d8a40bd82fc2f2d12a4e71242afe
 $ cd ..
+# see below for Mac OS specific instruction
 $ ant apply-patches
 $ ant build-netbeans
+
+```
+
+*Note for Mac OS*
+
+"apply-patches" task does not work properly on Mac OS. On Mac OS,
+NetBeans patches can be applied using the following commands:
+
+```bash
+$ cd netbeans/
+$ git apply ../patch/*
 
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -53,7 +53,7 @@ NetBeans patches can be applied using the following commands:
 
 ```bash
 $ cd netbeans/
-$ git apply ../patch/*
+$ git apply ../patches/*
 
 ```
 


### PR DESCRIPTION
1.  added Mac OS specific NetBeans patch application instruction.
2. fixed .gitignore for netbeans folder.
3. Only JDK 11 to JDK 20 can be used for build. JDK 21 cannot be used.
