### PR TITLE
Making sure tests can be run and pass, on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,12 +37,13 @@ jobs:
   # artifact is only produced once in the matrix
   base-build:
     name: Base Build
-    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
         java: [ '17' ]
+        os: [ ubuntu-latest ]
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
@@ -71,3 +72,9 @@ jobs:
 
       - name: Build the Visual Studio Extension
         run: ant build-vscode-ext
+
+      - name: Install virtual X server
+        run: sudo apt install -y xvfb
+
+      - name: Basic tests for the Visual Studio Extension
+        run: xvfb-run -a ant test-vscode-ext

--- a/BUILD.md
+++ b/BUILD.md
@@ -40,20 +40,9 @@ $ git clone https://github.com/apache/netbeans.git
 $ cd netbeans/
 $ git checkout f48f91e6c197d8a40bd82fc2f2d12a4e71242afe
 $ cd ..
-# see below for Mac OS specific instruction
+# the following target requires git executable to be on PATH:
 $ ant apply-patches
 $ ant build-netbeans
-
-```
-
-*Note for Mac OS*
-
-"apply-patches" task does not work properly on Mac OS. On Mac OS,
-NetBeans patches can be applied using the following commands:
-
-```bash
-$ cd netbeans/
-$ git apply ../patches/*
 
 ```
 
@@ -97,14 +86,14 @@ that there are VS Code integration tests - those launch VS Code with the
 VS extension and check behavior of the TypeScript integration code:
 
 ```bash
-java.lsp.server$ ant build-vscode-ext # first and then
-java.lsp.server$ ant test-vscode-ext
+$ ant build-vscode-ext # first and then
+$ ant test-vscode-ext
 ```
 
 In case you are behind a proxy, you may want to run the tests with
 
 ```bash
-java.lsp.server$ npm_config_https_proxy=http://your.proxy.com:port ant test-vscode-ext
+$ npm_config_https_proxy=http://your.proxy.com:port ant test-vscode-ext
 ```
 
 when executing the tests for the first time. That shall overcome the proxy

--- a/build.xml
+++ b/build.xml
@@ -31,6 +31,7 @@
     <property name="nbplatform.default.harness.dir" location="${nbplatform.default.netbeans.dest.dir}/harness" />
     <property name="nbantext.jar" location="netbeans/nbbuild/build/nbantext.jar" />
     <property name="nb_all" location="netbeans" />
+    <property name="patches" value="patches/6218.diff patches/6330.diff patches/6478-6480.diff patches/6481.diff patches/6771.diff patches/mvn-sh.diff patches/rename-debugger.diff" />
     <condition property="cmd.suffix" value=".cmd" else="">
         <os family="windows"/>
     </condition>
@@ -141,7 +142,11 @@
 	<delete file="${basedir}/vscode/THIRD_PARTY_LICENSES.txt"/>
     </target>
     <target name="test-lsp-server" description="Tests the LSP server behavior">
-        <ant dir="nbcode" target="test" inheritall="false" inheritrefs="false" />
+        <ant dir="nbcode" target="test" inheritall="false" inheritrefs="false">
+            <property name="nbplatform.default.netbeans.dest.dir" location="${nbplatform.default.netbeans.dest.dir}" />
+            <property name="nbplatform.default.harness.dir" location="${nbplatform.default.harness.dir}" />
+            <property name="nbantext.jar" location="${nbantext.jar}" />
+        </ant>
     </target>
 
     <target name="test-vscode-ext" depends="test-lsp-server" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
@@ -168,21 +173,42 @@
     </target>
 
     <target name="apply-patches">
-        <patch patchfile="patches/6218.diff" strip="1" dir="netbeans" failonerror="true"/>
-        <patch patchfile="patches/6330.diff" strip="1" dir="netbeans" failonerror="true"/>
-        <patch patchfile="patches/6478-6480.diff" strip="1" dir="netbeans" failonerror="true"/>
-        <patch patchfile="patches/6481.diff" strip="1" dir="netbeans" failonerror="true"/>
-        <patch patchfile="patches/mvn-sh.diff" strip="1" dir="netbeans" failonerror="true"/>
-        <patch patchfile="patches/rename-debugger.diff" strip="1" dir="netbeans" failonerror="true"/>
+        <exec executable="git">
+            <arg value="apply"/>
+            <arg value="--directory=netbeans"/>
+            <arg value="--whitespace=nowarn"/>
+            <arg line="${patches}"/>
+        </exec>
     </target>
 
     <target name="unapply-patches">
-        <patch patchfile="patches/rename-debugger.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
-        <patch patchfile="patches/mvn-sh.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
-        <patch patchfile="patches/6218.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
-        <patch patchfile="patches/6330.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
-        <patch patchfile="patches/6478-6480.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
-        <patch patchfile="patches/6481.diff" strip="1" dir="netbeans" failonerror="true" reverse="true"/>
+        <!--in the reverse order:-->
+        <echo file="${build.dir}/Reverse.java">
+            import java.util.Arrays;
+            import java.util.Collections;
+            import java.util.List;
+            import java.util.stream.Collectors;
+            public class Reverse {
+                 public static void main(String[] args) {
+                    List&lt;String> patches = Arrays.asList(args[0].split(" "));
+                    Collections.reverse(patches);
+                    System.out.print(patches.stream().collect(Collectors.joining(" ")));
+                 }
+            }
+        </echo>
+        <java sourcefile="${build.dir}/Reverse.java"
+              outputproperty="reverse.patches"
+              fork="true">
+             <arg value="${patches}" />
+        </java>
+        <echo>${reverse.patches}</echo>
+        <exec executable="git">
+            <arg value="apply"/>
+            <arg value="--directory=netbeans"/>
+            <arg value="--whitespace=nowarn"/>
+            <arg value="--reverse"/>
+            <arg line="${reverse.patches}"/>
+        </exec>
     </target>
 
     <target name="build-netbeans">

--- a/patches/6771.diff
+++ b/patches/6771.diff
@@ -1,0 +1,13 @@
+diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
+index d893783f6995..3f90097b6053 100644
+--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
++++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
+@@ -80,7 +80,7 @@
+ public final class SurroundWithHint extends CodeActionsProvider {
+ 
+     private static final String COMMAND_INSERT_SNIPPET = "editor.action.insertSnippet";
+-    private static final String COMMAND_SURROUND_WITH = "surround.with";
++    private static final String COMMAND_SURROUND_WITH = "nbls.surround.with";
+     private static final String DOTS = "...";
+     private static final String SNIPPET = "snippet";
+     private static final String SELECTION_VAR = "${selection}";

--- a/vscode/src/test/suite/extension.test.ts
+++ b/vscode/src/test/suite/extension.test.ts
@@ -167,6 +167,11 @@ suite('Extension Test Suite', function () {
         if (refactorActions && refactorActions.length > 0) {
             for await (const action of refactorActions) {
                 if (action.command && action.command.arguments) {
+                    if (action.command.command === myExtension.COMMAND_PREFIX + ".surround.with") {
+                        //this action has a popup where the user needs to
+                        //select a template that should be used for the surround:
+                        continue;
+                    }
                     await commands.executeCommand(action.command.command, ...action.command.arguments);
                     await commands.executeCommand('undo');
                 }


### PR DESCRIPTION
This patch fixes a few things around running tests + adds them to the GH Actions pipeline.

Specifically:
 - `ant test-vscode-ext` now passes on Linux (cannot try on Mac).
 - to do that, I needed this fix: https://github.com/apache/netbeans/pull/6771 , so including it as a patch.
 - the order of application of patches is becoming important, so manual `git apply *` may or may not work, depending on FS order. Tried to tweak the script to use `git apply` + avoiding duplication of the patch names (auto-reversing the list).
 - updates to `BUILD.md` to reflect all this + entry in the GH workflow
