### PR TITLE
Added option to delete workspace cache with respect to oracle java extension 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ As soon as one of the settings is changed, the Language Server is restarted.
 It is possible to run Oracle Java Platform extension per workspace (VSCode window). This allows separation of Language Server for given project as Language Server JVM is not shared for more VSCode open workspaces (projects).
 It is possible to change this in `View | Command Palette | Preferences:Open User Settings | Jdk: Userdir`. Set to `local` to use dedicated Language Server per workspace or set to `global` to have one Language Server for all VS Code workspaces.
 
+## Troubleshooting
+If your extension is not starting and throwing some error like no JDK found even if you have a working JDK installed in your machine, then you can try deleting cache for the workspace using `View | Command Palette | Delete oracle java extension cache for this workspace`. 
+
 ## Contributing
 
 This project welcomes contributions from the community. Before submitting a pull request, please [review our contribution guide](./CONTRIBUTING.md)

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -168,6 +168,9 @@ As soon as one of the settings is changed, the Language Server is restarted.
 It is possible to run Oracle Java Platform extension per workspace (VSCode window). This allows separation of Language Server for given project as Language Server JVM is not shared for more VSCode open workspaces (projects).
 It is possible to change this in `View | Command Palette | Preferences:Open User Settings | Jdk: Userdir`. Set to `local` to use dedicated Language Server per workspace or set to `global` to have one Language Server for all VS Code workspaces.
 
+## Troubleshooting
+If your extension is not starting and throwing some error like no JDK found even if you have a working JDK installed in your machine, then you can try deleting cache for the workspace using `View | Command Palette | Delete oracle java extension cache for this workspace`.
+
 ## Contributing
 
 This project welcomes contributions from the community. Before submitting a pull request, please [review our contribution guide](../CONTRIBUTING.md)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -445,6 +445,10 @@
 				"command": "jdk.goto.test",
 				"title": "Go To Test/Tested class...",
 				"category": "Java"
+			},
+			{
+				"command": "jdk.delete.cache",
+				"title": "Delete oracle java extension cache for this workspace"
 			}
 		],
 		"keybindings": [

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -486,6 +486,29 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             throw `Client ${c} doesn't support go to test`;
         }
     }));
+
+    context.subscriptions.push(vscode.commands.registerCommand(COMMAND_PREFIX + ".delete.cache", async () => {
+        const storagePath = context.storageUri?.fsPath;
+        if(!storagePath){
+            vscode.window.showErrorMessage('Cannot find workspace path');
+            return;
+        }
+        const userDir = path.join(storagePath, "userdir");
+        if (userDir && fs.existsSync(userDir)) {
+            const confirmation = await vscode.window.showInformationMessage('Are you sure you want to delete cache for this workspace?',
+                'Yes', 'Cancel');
+            if (confirmation === 'Yes') {
+                await fs.promises.rmdir(userDir, {recursive : true});
+                const res = await vscode.window.showInformationMessage('Cache cleared successfully for this workspace', 'Reload window');
+                if (res === 'Reload window') {
+                    await vscode.commands.executeCommand('workbench.action.reloadWindow');
+                }
+            }
+        } else {
+            vscode.window.showErrorMessage('Cannot find userdir path');
+        }
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand(COMMAND_PREFIX + ".download.jdk", async () => { openJDKSelectionView(log); }));
     context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.workspace.compile', () =>
         wrapCommandWithProgress(COMMAND_PREFIX + '.build.workspace', 'Compiling workspace...', log, true)


### PR DESCRIPTION
As seen in issue #110, sometimes cache issue can occur and user needs to delete userdir as part of troubleshooting step for that workspace. So, added a command to delete extension cache for a particular workspace.