### PR TITLE
Adding an advanced option to disable the embedded nb-javac, hence use javac from the JDK.

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -194,6 +194,11 @@
 					"type": "string",
 					"default": "",
 					"description": "Working directory"
+				},
+				"jdk.advanced.disable.nbjavac": {
+					"type": "boolean",
+					"default": false,
+					"description": "Advanced option: disable nb-javac library, javac from the selected JDK will be used. The selected JDK must be at least JDK 22."
 				}
 			}
 		},

--- a/vscode/src/nbcode.ts
+++ b/vscode/src/nbcode.ts
@@ -33,6 +33,8 @@ export interface LaunchInfo {
     storagePath: string;
     jdkHome: string | unknown;
     verbose? : boolean;
+    enableModules? : string[];
+    disableModules? : string[];
 }
 
 function find(info: LaunchInfo): string {
@@ -53,6 +55,30 @@ function find(info: LaunchInfo): string {
     return nbcodePath;
 }
 
+function enableDisableModules(
+    info: LaunchInfo,
+    userDir : string,
+    modules : string[] | undefined,
+    enable : boolean) {
+    if (modules) {
+        for (var i = 0; i < modules.length; i++) {
+            const module = modules[i];
+            const moduleXml : string = module.replace(/\./g, "-") + ".xml";
+            var xmlContent : string = "";
+            const clusters : string[] = fs.readdirSync(path.join(info.extensionPath, "nbcode"));
+            for (var c = 0; c < clusters.length; c++) {
+                const sourceXmlPath : string = path.join(info.extensionPath, "nbcode", clusters[c], "config", "Modules", moduleXml);
+                if (fs.existsSync(sourceXmlPath)) {
+                    xmlContent = fs.readFileSync(sourceXmlPath).toString();
+                }
+            }
+            xmlContent = xmlContent.replace(`<param name="enabled">${!enable}</param>`, `<param name="enabled">${enable}</param>`);
+            fs.mkdirSync(path.join(userDir, "config", "Modules"), {recursive: true});
+            fs.writeFileSync(path.join(userDir, "config", "Modules", moduleXml), xmlContent);
+        }
+    }
+}
+
 export function launch(
     info: LaunchInfo,
     ...extraArgs : string[]
@@ -65,6 +91,9 @@ export function launch(
     if (!userDirPerm.isDirectory()) {
         throw `Cannot create ${userDir}`;
     }
+
+    enableDisableModules(info, userDir, info.disableModules, false);
+    enableDisableModules(info, userDir, info.enableModules, true);
 
     let clusterPath = info.clusters.join(path.delimiter);
     let ideArgs: string[] = [


### PR DESCRIPTION
This should allow easier experiments with early access JDK builds - those can be specified in `jdk.jdkhome`, and nb-javac can be disabled, so that the javac from the early access build is used by the extension.