### PR TITLE
Disable unused modules

### DIFF
--- a/nbcode/nbproject/platform.properties
+++ b/nbcode/nbproject/platform.properties
@@ -29,7 +29,7 @@ cluster.path=\
     ${nbplatform.active.dir}/platform:\
     ${nbplatform.active.dir}/webcommon
 disabled.modules=\
-        bcpg,\
+    bcpg,\
     bcpkix,\
     bcprov,\
     bcutil,\

--- a/nbcode/nbproject/platform.properties
+++ b/nbcode/nbproject/platform.properties
@@ -29,10 +29,15 @@ cluster.path=\
     ${nbplatform.active.dir}/platform:\
     ${nbplatform.active.dir}/webcommon
 disabled.modules=\
-    bcpg,\
+        bcpg,\
     bcpkix,\
     bcprov,\
     bcutil,\
+    com.jcraft.jsch,\
+    com.jcraft.jzlib,\
+    net.java.html.boot.fx,\
+    net.java.html.geo,\
+    net.java.html.sound,\
     org.apache.commons.httpclient,\
     org.apache.commons.lang,\
     org.apache.ws.commons.util,\
@@ -70,12 +75,18 @@ disabled.modules=\
     org.netbeans.lib.nbjshell,\
     org.netbeans.lib.nbjshell9,\
     org.netbeans.lib.terminalemulator,\
+    org.netbeans.lib.uihandler,\
+    org.netbeans.lib.v8debug,\
+    org.netbeans.libs.batik.read,\
     org.netbeans.libs.cglib,\
     org.netbeans.libs.commons_net,\
     org.netbeans.libs.felix,\
+    org.netbeans.libs.git,\
     org.netbeans.libs.ini4j,\
+    org.netbeans.libs.javafx,\
     org.netbeans.libs.jsr223,\
     org.netbeans.libs.jstestdriver,\
+    org.netbeans.libs.nashorn,\
     org.netbeans.libs.nbi.ant,\
     org.netbeans.libs.nbi.engine,\
     org.netbeans.libs.plist,\
@@ -104,6 +115,7 @@ disabled.modules=\
     org.netbeans.modules.cordova.platforms.android,\
     org.netbeans.modules.core.kit,\
     org.netbeans.modules.css.editor,\
+    org.netbeans.modules.css.lib,\
     org.netbeans.modules.css.model,\
     org.netbeans.modules.css.prep,\
     org.netbeans.modules.css.visual,\
@@ -114,6 +126,7 @@ disabled.modules=\
     org.netbeans.modules.db.mysql,\
     org.netbeans.modules.db.sql.visualeditor,\
     org.netbeans.modules.dbapi,\
+    org.netbeans.modules.dbschema,\
     org.netbeans.modules.deadlock.detector,\
     org.netbeans.modules.debugger.jpda.ant,\
     org.netbeans.modules.debugger.jpda.js,\
@@ -130,6 +143,7 @@ disabled.modules=\
     org.netbeans.modules.docker.ui,\
     org.netbeans.modules.editor.autosave,\
     org.netbeans.modules.editor.bookmarks,\
+    org.netbeans.modules.editor.deprecated.pre65formatting,\
     org.netbeans.modules.editor.global.format,\
     org.netbeans.modules.editor.htmlui,\
     org.netbeans.modules.editor.kit,\
@@ -150,10 +164,15 @@ disabled.modules=\
     org.netbeans.modules.gradle.java.coverage,\
     org.netbeans.modules.gradle.kit,\
     org.netbeans.modules.gradle.spring,\
+    org.netbeans.modules.gsf.codecoverage,\
     org.netbeans.modules.html.angular,\
     org.netbeans.modules.html.custom,\
     org.netbeans.modules.html.editor,\
+    org.netbeans.modules.html.editor.lib,\
+    org.netbeans.modules.html.indexing,\
     org.netbeans.modules.html.knockout,\
+    org.netbeans.modules.html.lexer,\
+    org.netbeans.modules.html.parser,\
     org.netbeans.modules.html.validation,\
     org.netbeans.modules.httpserver,\
     org.netbeans.modules.hudson,\
@@ -198,22 +217,29 @@ disabled.modules=\
     org.netbeans.modules.javascript.jstestdriver,\
     org.netbeans.modules.javascript.karma,\
     org.netbeans.modules.javascript.nodejs,\
+    org.netbeans.modules.javascript.v8debug,\
     org.netbeans.modules.javascript.v8debug.ui,\
     org.netbeans.modules.javascript2.debug.ui,\
+    org.netbeans.modules.javascript2.doc,\
+    org.netbeans.modules.javascript2.editor,\
     org.netbeans.modules.javascript2.extdoc,\
     org.netbeans.modules.javascript2.extjs,\
     org.netbeans.modules.javascript2.html,\
     org.netbeans.modules.javascript2.jade,\
     org.netbeans.modules.javascript2.jquery,\
     org.netbeans.modules.javascript2.jsdoc,\
+    org.netbeans.modules.javascript2.json,\
     org.netbeans.modules.javascript2.kit,\
     org.netbeans.modules.javascript2.knockout,\
+    org.netbeans.modules.javascript2.lexer,\
+    org.netbeans.modules.javascript2.model,\
     org.netbeans.modules.javascript2.nodejs,\
     org.netbeans.modules.javascript2.prototypejs,\
     org.netbeans.modules.javascript2.react,\
     org.netbeans.modules.javascript2.requirejs,\
     org.netbeans.modules.javascript2.sdoc,\
     org.netbeans.modules.javascript2.source.query,\
+    org.netbeans.modules.javascript2.types,\
     org.netbeans.modules.javawebstart,\
     org.netbeans.modules.jellytools.ide,\
     org.netbeans.modules.jellytools.java,\
@@ -234,6 +260,10 @@ disabled.modules=\
     org.netbeans.modules.localhistory,\
     org.netbeans.modules.localtasks,\
     org.netbeans.modules.lsp.client,\
+    org.netbeans.modules.markdown,\
+    org.netbeans.modules.masterfs.linux,\
+    org.netbeans.modules.masterfs.macosx,\
+    org.netbeans.modules.masterfs.windows,\
     org.netbeans.modules.maven.checkstyle,\
     org.netbeans.modules.maven.coverage,\
     org.netbeans.modules.maven.grammar,\
@@ -257,6 +287,7 @@ disabled.modules=\
     org.netbeans.modules.projectui.buildmenu,\
     org.netbeans.modules.selenium2.java,\
     org.netbeans.modules.selenium2.maven,\
+    org.netbeans.modules.selenium2.webclient,\
     org.netbeans.modules.selenium2.webclient.mocha,\
     org.netbeans.modules.selenium2.webclient.protractor,\
     org.netbeans.modules.servletapi,\
@@ -280,6 +311,7 @@ disabled.modules=\
     org.netbeans.modules.testng.ant,\
     org.netbeans.modules.testng.maven,\
     org.netbeans.modules.typescript.editor,\
+    org.netbeans.modules.uihandler,\
     org.netbeans.modules.uihandler.exceptionreporter,\
     org.netbeans.modules.usersguide,\
     org.netbeans.modules.utilities,\
@@ -316,6 +348,7 @@ disabled.modules=\
     org.netbeans.modules.xsl,\
     org.netbeans.spi.editor.hints.projects,\
     org.netbeans.swing.dirchooser,\
+    org.netbeans.swing.laf.dark,\
     org.netbeans.upgrader,\
     org.openide.compat,\
     org.openide.execution.compat8,\

--- a/nbcode/nbproject/platform.properties
+++ b/nbcode/nbproject/platform.properties
@@ -90,9 +90,11 @@ disabled.modules=\
     org.netbeans.libs.nbi.ant,\
     org.netbeans.libs.nbi.engine,\
     org.netbeans.libs.plist,\
+    org.netbeans.libs.snakeyaml_engine,\
     org.netbeans.libs.springframework,\
     org.netbeans.libs.svnClientAdapter,\
     org.netbeans.libs.svnClientAdapter.javahl,\
+    org.netbeans.libs.tomlj,\
     org.netbeans.libs.xerces,\
     org.netbeans.modules.ant.browsetask,\
     org.netbeans.modules.ant.debugger,\
@@ -124,6 +126,7 @@ disabled.modules=\
     org.netbeans.modules.db.drivers,\
     org.netbeans.modules.db.kit,\
     org.netbeans.modules.db.mysql,\
+    org.netbeans.modules.db.sql.editor,\
     org.netbeans.modules.db.sql.visualeditor,\
     org.netbeans.modules.dbapi,\
     org.netbeans.modules.dbschema,\
@@ -151,6 +154,7 @@ disabled.modules=\
     org.netbeans.modules.editor.plain,\
     org.netbeans.modules.editor.plain.lib,\
     org.netbeans.modules.editor.search,\
+    org.netbeans.modules.editor.structure,\
     org.netbeans.modules.extbrowser,\
     org.netbeans.modules.extbrowser.chrome,\
     org.netbeans.modules.extexecution.impl,\
@@ -165,6 +169,7 @@ disabled.modules=\
     org.netbeans.modules.gradle.kit,\
     org.netbeans.modules.gradle.spring,\
     org.netbeans.modules.gsf.codecoverage,\
+    org.netbeans.modules.html,\
     org.netbeans.modules.html.angular,\
     org.netbeans.modules.html.custom,\
     org.netbeans.modules.html.editor,\
@@ -257,6 +262,8 @@ disabled.modules=\
     org.netbeans.modules.languages.hcl,\
     org.netbeans.modules.languages.ini,\
     org.netbeans.modules.languages.manifest,\
+    org.netbeans.modules.languages.toml,\
+    org.netbeans.modules.languages.yaml,\
     org.netbeans.modules.localhistory,\
     org.netbeans.modules.localtasks,\
     org.netbeans.modules.lsp.client,\
@@ -285,8 +292,10 @@ disabled.modules=\
     org.netbeans.modules.projectimport.eclipse.core,\
     org.netbeans.modules.projectimport.eclipse.j2se,\
     org.netbeans.modules.projectui.buildmenu,\
+    org.netbeans.modules.selenium2,\
     org.netbeans.modules.selenium2.java,\
     org.netbeans.modules.selenium2.maven,\
+    org.netbeans.modules.selenium2.server,\
     org.netbeans.modules.selenium2.webclient,\
     org.netbeans.modules.selenium2.webclient.mocha,\
     org.netbeans.modules.selenium2.webclient.protractor,\
@@ -307,6 +316,7 @@ disabled.modules=\
     org.netbeans.modules.tasklist.ui,\
     org.netbeans.modules.team.commons,\
     org.netbeans.modules.team.ide,\
+    org.netbeans.modules.terminal,\
     org.netbeans.modules.terminal.nb,\
     org.netbeans.modules.testng.ant,\
     org.netbeans.modules.testng.maven,\
@@ -321,6 +331,7 @@ disabled.modules=\
     org.netbeans.modules.versioning.system.cvss.installer,\
     org.netbeans.modules.versioning.ui,\
     org.netbeans.modules.versioning.util,\
+    org.netbeans.modules.web.browser.api,\
     org.netbeans.modules.web.client.kit,\
     org.netbeans.modules.web.client.samples,\
     org.netbeans.modules.web.clientproject,\

--- a/nbcode/nbproject/platform.properties
+++ b/nbcode/nbproject/platform.properties
@@ -359,7 +359,6 @@ disabled.modules=\
     org.netbeans.modules.xsl,\
     org.netbeans.spi.editor.hints.projects,\
     org.netbeans.swing.dirchooser,\
-    org.netbeans.swing.laf.dark,\
     org.netbeans.upgrader,\
     org.openide.compat,\
     org.openide.execution.compat8,\


### PR DESCRIPTION
This PR aims to disable some obvious unused modules to reduce the size of the extension. After disabling all these modules the size of the extension reduces to almost 137 MB from almost 154 MB.