### PR TITLE
JAVAVSCODE-199 Quick Fix actions are unable to edit runConfig options in global settings for non-workspace opened Java files

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1100,8 +1100,24 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 return selected ? Array.isArray(selected) ? selected : [selected] : undefined;
             });
             c.onRequest(UpdateConfigurationRequest.type, async (param) => {
-                await vscode.workspace.getConfiguration(param.section).update(param.key, param.value);
-                runConfigurationUpdateAll();
+                handleLog(log, "Received config update: " + param.section + "." + param.key + "=" + param.value);
+                if (vscode.workspace) {
+                    let wsFile: vscode.Uri | undefined = vscode.workspace.workspaceFile;
+                    let wsConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(param.section);
+                    if (wsConfig) {
+                        try {
+                            wsConfig.update(param.key, param.value, wsFile ? null : true)
+                                .then(() => {
+                                    handleLog(log, "Updated configuration: " + param.section + "." + param.key + "=" + param.value + "; in: " + (wsFile ? wsFile.toString() : "Global"));
+                                })
+                                .then(() => {
+                                    runConfigurationUpdateAll();
+                                });
+                        } catch (err) {
+                            handleLog(log, "Failed to update configuration. Reason: " + (typeof err === "string" ? err : err instanceof Error ? err.message : "error"));
+                        }
+                    }
+                }
             });
             c.onRequest(SaveDocumentsRequest.type, async (request : SaveDocumentRequestParams) => {
                 const uriList = request.documents.map(s => {


### PR DESCRIPTION
Fixed extension.ts `UpdateConfigurationRequest` handler to update the global `WorkspaceConfiguration` for non-workspace opened files.

1. Checked for non-workspace opened files by testing if `vscode.workspace.workspaceFile` is undefined/null.
2. Invoked `WorkspaceConfiguration.update()` with `configurationTarget = `:
    - `true`: for non-workspace files;
    - `null`: otherwise.
4. Added a try-catch to log errors in update and prevent downstream failures.
5. Avoided an unnecessary `await` and used the `Thenable` chain of `update()`.

Fixes #199