### PR TITLE
Fix formatting issue of xml files

### DIFF
--- a/nbcode/nbproject/platform.properties
+++ b/nbcode/nbproject/platform.properties
@@ -146,7 +146,6 @@ disabled.modules=\
     org.netbeans.modules.docker.ui,\
     org.netbeans.modules.editor.autosave,\
     org.netbeans.modules.editor.bookmarks,\
-    org.netbeans.modules.editor.deprecated.pre65formatting,\
     org.netbeans.modules.editor.global.format,\
     org.netbeans.modules.editor.htmlui,\
     org.netbeans.modules.editor.kit,\
@@ -154,7 +153,6 @@ disabled.modules=\
     org.netbeans.modules.editor.plain,\
     org.netbeans.modules.editor.plain.lib,\
     org.netbeans.modules.editor.search,\
-    org.netbeans.modules.editor.structure,\
     org.netbeans.modules.extbrowser,\
     org.netbeans.modules.extbrowser.chrome,\
     org.netbeans.modules.extexecution.impl,\


### PR DESCRIPTION
Adding modules `org.netbeans.modules.editor.deprecated.pre65formatting` and `org.netbeans.modules.editor.structure` back into the extension.

closes #185 