### PR TITLE
Backport NB23 patch 7390 to fix the Exception template

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,6 +40,7 @@
             patches/7368.diff
             patches/7370.diff
             patches/7382.diff
+            patches/7390.diff
             patches/7491-preliminary.diff
             patches/7497.diff
             patches/7548_source-1.8.diff

--- a/patches/7390.diff
+++ b/patches/7390.diff
@@ -1,0 +1,13 @@
+diff --git a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template
+index ab05caa21d2e..bdccca88f8e3 100644
+--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template
++++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template
+@@ -33,7 +33,7 @@ import ${interface};
+     </#list>
+     <#assign implementation = "${implementation}"?remove_ending(", ")>
+ </#if>
+-public class ${name}<#if extension?? && extension != ""> extends ${extension}</#if><#if implementation?? && implementation != ""> implements ${implementation}</#if> {
++public class ${name}<#if extension?? && extension != ""> extends ${extension}<#else> extends Exception</#if><#if implementation?? && implementation != ""> implements ${implementation}</#if> {
+ 
+     /**
+      * Creates a new instance of <code>${name}</code> without detail message.


### PR DESCRIPTION
In NB23, [patch #7390](https://github.com/apache/netbeans/pull/7390) fixed the regression where the newly created exception from template did not extend Exception, thereby failing to compile.

This temporarily backports the fix until NB23 is incorporated.