### PR TITLE
Backport NB patch for Gradle tooling 8.10 upgrade

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -49,6 +49,7 @@
             patches/7621.diff
             patches/7641.diff
             patches/7654.diff
+            patches/7690.diff
             patches/mvn-sh.diff
             patches/generate-dependencies.diff
             patches/rename-debugger.diff

--- a/patches/7690.diff
+++ b/patches/7690.diff
@@ -1,0 +1,83 @@
+diff --git a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+index 8b93f19d3208..051d95a2cb8b 100644
+--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
++++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+@@ -100,9 +100,10 @@ public final class GradleDistributionManager {
+         GradleVersion.version("8.3"), // JDK-20
+         GradleVersion.version("8.5"), // JDK-21
+         GradleVersion.version("8.8"), // JDK-22
++        GradleVersion.version("8.10"),// JDK-23
+     };
+ 
+-    private static final GradleVersion LAST_KNOWN_GRADLE = GradleVersion.version("8.9"); //NOI18N
++    private static final GradleVersion LAST_KNOWN_GRADLE = GradleVersion.version("8.10"); //NOI18N
+ 
+     final File gradleUserHome;
+ 
+diff --git a/extide/libs.gradle/external/binaries-list b/extide/libs.gradle/external/binaries-list
+index dff2c2265b37..72218b9d5a29 100644
+--- a/extide/libs.gradle/external/binaries-list
++++ b/extide/libs.gradle/external/binaries-list
+@@ -15,4 +15,4 @@
+ # specific language governing permissions and limitations
+ # under the License.
+ 
+-7BCC4423C529A42ECA9D0CE5B5275369EF4DF55A https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.9/gradle-tooling-api-8.9.jar gradle-tooling-api-8.9.jar
++1FC754376876B11AE26D811F8812AA37773660DD https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.10/gradle-tooling-api-8.10.jar gradle-tooling-api-8.10.jar
+diff --git a/extide/libs.gradle/external/gradle-tooling-api-8.9-license.txt b/extide/libs.gradle/external/gradle-tooling-api-8.10-license.txt
+similarity index 99%
+rename from extide/libs.gradle/external/gradle-tooling-api-8.9-license.txt
+rename to extide/libs.gradle/external/gradle-tooling-api-8.10-license.txt
+index 74cb1addb8d6..ab7d5a2a2558 100644
+--- a/extide/libs.gradle/external/gradle-tooling-api-8.9-license.txt
++++ b/extide/libs.gradle/external/gradle-tooling-api-8.10-license.txt
+@@ -1,7 +1,7 @@
+ Name: Gradle Tooling API
+ Description: Gradle Tooling API
+-Version: 8.9
+-Files: gradle-tooling-api-8.9.jar
++Version: 8.10
++Files: gradle-tooling-api-8.10.jar
+ License: Apache-2.0
+ Origin: Gradle Inc.
+ URL: https://gradle.org/
+diff --git a/extide/libs.gradle/external/gradle-tooling-api-8.9-notice.txt b/extide/libs.gradle/external/gradle-tooling-api-8.10-notice.txt
+similarity index 100%
+rename from extide/libs.gradle/external/gradle-tooling-api-8.9-notice.txt
+rename to extide/libs.gradle/external/gradle-tooling-api-8.10-notice.txt
+diff --git a/extide/libs.gradle/nbproject/project.properties b/extide/libs.gradle/nbproject/project.properties
+index 6e4605fe4922..d20b5a229d4c 100644
+--- a/extide/libs.gradle/nbproject/project.properties
++++ b/extide/libs.gradle/nbproject/project.properties
+@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
+ # Sigtest fails to read the classes in the gradle-tooling-api
+ sigtest.skip.gen=true
+ 
+-release.external/gradle-tooling-api-8.9.jar=modules/gradle/gradle-tooling-api.jar
++release.external/gradle-tooling-api-8.10.jar=modules/gradle/gradle-tooling-api.jar
+diff --git a/extide/libs.gradle/nbproject/project.xml b/extide/libs.gradle/nbproject/project.xml
+index d82027b5e615..9b1dfe36f2ad 100644
+--- a/extide/libs.gradle/nbproject/project.xml
++++ b/extide/libs.gradle/nbproject/project.xml
+@@ -39,7 +39,7 @@
+             </public-packages>
+             <class-path-extension>
+                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
+-                <binary-origin>external/gradle-tooling-api-8.9.jar</binary-origin>
++                <binary-origin>external/gradle-tooling-api-8.10.jar</binary-origin>
+             </class-path-extension>
+         </data>
+     </configuration>
+diff --git a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java
+index 255def8bce12..031c25128452 100644
+--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java
++++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java
+@@ -35,7 +35,7 @@ public final class Wizards {
+ 
+     private Wizards() {};
+ 
+-    private static final List<Integer> JAVA_VERSIONS = List.of(22, 21, 17, 11, 8);
++    private static final List<Integer> JAVA_VERSIONS = List.of(23, 22, 21, 17, 11, 8);
+     private static final List<TestFramework> JAVA_TEST_FRAMEWORKS = List.of(
+             JUNIT,
+             JUNIT_5,


### PR DESCRIPTION
This version of Gradle brings full JDK23 support.

- Manually verified `shasum` of the gradle-tooling-api-8.10.jar recorded in the *extide/libs.gradle/external/binaries-list* file. 
    - Especially important since this [PR 7690](https://github.com/apache/netbeans/pull/7690) is still a draft and not approved.

- BA available.