### PR TITLE
Correctly pick configuration from launch settings during run and debug sessions

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -607,13 +607,13 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     }));
 
     async function findRunConfiguration(uri : vscode.Uri) : Promise<vscode.DebugConfiguration|undefined> {
-        // do not invoke debug start with no (java+) configurations, as it would probably create an user prompt
+        // do not invoke debug start with no (jdk) configurations, as it would probably create an user prompt
         let cfg = vscode.workspace.getConfiguration("launch");
         let c = cfg.get('configurations');
         if (!Array.isArray(c)) {
             return undefined;
         }
-        let f = c.filter((v) => v['type'] === 'java+');
+        let f = c.filter((v) => v['type'] === 'jdk');
         if (!f.length) {
             return undefined;
         }
@@ -626,10 +626,10 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             }
         }
         let provider = new P();
-        let d = vscode.debug.registerDebugConfigurationProvider('java+', provider);
+        let d = vscode.debug.registerDebugConfigurationProvider('jdk', provider);
         // let vscode to select a debug config
         return await vscode.commands.executeCommand('workbench.action.debug.start', { config: {
-            type: 'java+',
+            type: 'jdk',
             mainClass: uri.toString()
         }, noDebug: true}).then((v) => {
             d.dispose();


### PR DESCRIPTION
This PR addresses an issue where the active launch configuration was not being correctly detected, leading to tests and other panels not receiving the proper settings during run and debug sessions. The changes ensure that the correct launch configuration is picked up, allowing for consistent and accurate behavior across all relevant panels.