### PR TITLE
Add copyrights in missing places

### DIFF
--- a/vscode/src/jdkDownloader/action.ts
+++ b/vscode/src/jdkDownloader/action.ts
@@ -1,3 +1,19 @@
+/*
+  Copyright (c) 2023-2024, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import { commands, OpenDialogOptions, OutputChannel, window, workspace } from "vscode";
 import { JdkDownloaderView } from "./view";
 import { OPEN_JDK_VERSION_DOWNLOAD_LINKS, ORACLE_JDK_BASE_DOWNLOAD_URL } from "../constants";

--- a/vscode/src/jdkDownloader/styles.ts
+++ b/vscode/src/jdkDownloader/styles.ts
@@ -1,3 +1,19 @@
+/*
+  Copyright (c) 2023-2024, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 export const downloaderCss = `
 .select-jdk {
     background-color: #007ACC;

--- a/vscode/src/jdkDownloader/view.ts
+++ b/vscode/src/jdkDownloader/view.ts
@@ -1,3 +1,19 @@
+/*
+  Copyright (c) 2023-2024, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import { OPEN_JDK_VERSION_DOWNLOAD_LINKS, ORACLE_JDK_DOWNLOAD_VERSIONS } from '../constants';
 import { OutputChannel, Uri, ViewColumn, WebviewPanel, window } from 'vscode';
 import * as os from 'os';

--- a/vscode/src/localiser.ts
+++ b/vscode/src/localiser.ts
@@ -1,5 +1,20 @@
-'use strict';
+/*
+  Copyright (c) 2023-2024, Oracle and/or its affiliates.
 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
 
 import * as l10nLib from '@vscode/l10n'
 


### PR DESCRIPTION
During refactor of JDK downloader and addition of localization, copyright notice in the newly created files were missing. So, adding appropriate copyright notices.