### PR TITLE
Fixed JDK Downloader windows ARM64 download issue

### DIFF
--- a/vscode/src/constants.ts
+++ b/vscode/src/constants.ts
@@ -22,7 +22,7 @@ export const ORACLE_JDK_BASE_DOWNLOAD_URL = `https://download.oracle.com/java`;
 export const ORACLE_JDK_DOWNLOAD_VERSIONS = ['23','21'];
 
 export const OPEN_JDK_VERSION_DOWNLOAD_LINKS: { [key: string]: string } = {
-  "23": "https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL/openjdk-23"
+  "23": "https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1"
 };
 
 export const ORACLE_VSCODE_EXTENSION_ID = 'oracle.oracle-java';

--- a/vscode/src/jdkDownloader/view.ts
+++ b/vscode/src/jdkDownloader/view.ts
@@ -201,8 +201,12 @@ export class JdkDownloaderView {
     }
 
     private getMachineArchHtml = () => {
-        return `<option value="aarch64" ${this.machineArch === 'aarch64' ? 'selected' : null}>arm64</option>
-                <option value="x64" ${this.machineArch === 'x64' ? 'selected' : null}>x64</option>`
+        if (this.osType === 'windows') {
+            return `<option value="x64" selected>x64</option>`;
+        } else {
+            return `<option value="aarch64" ${this.machineArch === 'aarch64' ? 'selected' : null}>arm64</option>
+                    <option value="x64" ${this.machineArch === 'x64' ? 'selected' : null}>x64</option>`;
+        }
     }
 
     private getScriptJs = () => {
@@ -233,6 +237,28 @@ export class JdkDownloaderView {
                 document.getElementById("oracleJDKDownloadButton")?.addEventListener('click', event => {
                     triggerJDKDownload(event);
                 });
+
+                document.getElementById("oracleJDKOsTypeDropdown")?.addEventListener('change', (event) => {
+                    updateMachineArchOptions(event.target.id);
+                });
+
+                document.getElementById("openJDKOsTypeDropdown")?.addEventListener('change', (event) => {
+                    updateMachineArchOptions(event.target.id);
+                });
+                
+                const updateMachineArchOptions = (osDropdownId) => {
+                    const osDropdown = document.getElementById(osDropdownId);
+                    const machineArchDropdown = document.getElementById(osDropdownId.replace('OsTypeDropdown', 'MachineArchDropdown'));
+                    
+                    if (osDropdown.value === 'windows') {
+                        machineArchDropdown.innerHTML = '<option value="x64" selected>x64</option>';
+                    } else {
+                        machineArchDropdown.innerHTML = \`
+                            <option value="aarch64" \${machineArchDropdown.value === 'aarch64' ? 'selected' : null}>arm64</option>
+                            <option value="x64" \${machineArchDropdown.value === 'x64' ? 'selected' : null}>x64</option>
+                        \`;
+                    }
+                };
 
                 const hideOrDisplayDivs = (e) => {
                     const { id } = e.target;


### PR DESCRIPTION
This PR aims to remove option to download JDK for Windows ARM64 since it is not available.
Closes #291 