### PR TITLE
[JVSC-300] Remove quoting in nbcode launch arguments

### DIFF
--- a/vscode/src/nbcode.ts
+++ b/vscode/src/nbcode.ts
@@ -105,13 +105,13 @@ export function launch(
     }
 
     if (info.projectSearchRoots) {
-        ideArgs.push(`-J-Dproject.limitScanRoot="${info.projectSearchRoots}"`);
+        ideArgs.push(`-J-Dproject.limitScanRoot=${info.projectSearchRoots}`);
     }
 
     if (info.verbose) {
         ideArgs.push('-J-Dnetbeans.logger.console=true');
     }
-    ideArgs.push(`-J-Dnetbeans.extra.dirs="${clusterPath}"`)
+    ideArgs.push(`-J-Dnetbeans.extra.dirs=${clusterPath}`)
     if (env['netbeans.extra.options']) {     
         ideArgs.push(...env['netbeans.extra.options'].split(' '));
     }


### PR DESCRIPTION
- The nbcode executable is launched from the ts/js extension using Node's `child_process.spawn` function.
    - This function directly launches the command in a new process. It does NOT create a shell to execute it; unlike `child_process.exec`.
- Therefore, quoting the arguments passed to prevent shell splitting is not required.
    - In fact, due to the presence of extra quotes, it may lead to incorrect splitting of arguments with spaces in them.
    - This is the cause for the initialization failure of the extension nbls when the project folder opened contains spaces in its path.
- Fixed *nbcode.ts* to remove the extra quotes added for some of the option values.

Closes #300