### PR TITLE
Fix Netbeans tests failures on MacOS

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -59,6 +59,7 @@
             patches/7910.diff
             patches/7921.diff
             patches/7923_draft.diff
+            patches/7926.diff
             patches/mvn-sh.diff
             patches/generate-dependencies.diff
             patches/rename-debugger.diff

--- a/patches/7926.diff
+++ b/patches/7926.diff
@@ -1,0 +1,54 @@
+diff --git a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5-nonmac.pass b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5-nonmac.pass
+deleted file mode 100644
+index 6564d61694f4..000000000000
+--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5-nonmac.pass
++++ /dev/null
+@@ -1,3 +0,0 @@
+-5:8-5:14:error:cannot find symbol
+-  symbol:method create()
+-  location:class TestShortErrors5
+diff --git a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass
+index a040a93300df..6564d61694f4 100644
+--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass
++++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass
+@@ -1 +1,3 @@
+-5:8-5:14:error:compiler message file broken:key=compiler.err.cant.resolve.location.args arguments=method, create, , , class, javahints.TestShortErrors5, {6}, {7}
++5:8-5:14:error:cannot find symbol
++  symbol:method create()
++  location:class TestShortErrors5
+diff --git a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning-nonmac.pass b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning-nonmac.pass
+deleted file mode 100644
+index a04bd4bb6bc3..000000000000
+--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning-nonmac.pass
++++ /dev/null
+@@ -1 +0,0 @@
+-2:13-2:40:warning:[serial] serializable class TestShortErrorsSVUIDWarning has no definition of serialVersionUID
+diff --git a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass
+index 24348a1a6a23..a04bd4bb6bc3 100644
+--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass
++++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass
+@@ -1 +1 @@
+-2:13-2:40:warning:serializable class javahints.TestShortErrorsSVUIDWarning has no definition of serialVersionUID
++2:13-2:40:warning:[serial] serializable class TestShortErrorsSVUIDWarning has no definition of serialVersionUID
+diff --git a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
+index f173387f11f7..de225bbab0d4 100644
+--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
++++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
+@@ -180,7 +180,7 @@ public void testShortErrors4() throws Exception {
+     }
+     
+     public void testShortErrors5() throws Exception {
+-        performTest("TestShortErrors5", true);
++        performTest("TestShortErrors5", false);
+     }
+     
+     public void testShortErrors6() throws Exception {
+@@ -228,7 +228,7 @@ public void testTestShortErrorsSVUIDWarning() throws Exception {
+         TestCompilerSettings.commandLine = "-Xlint:serial";
+ 
+         try {
+-            performTest("TestShortErrorsSVUIDWarning", true);
++            performTest("TestShortErrorsSVUIDWarning", false);
+         } finally {
+             TestCompilerSettings.commandLine = null;
+         }


### PR DESCRIPTION
Adding the patch for the netbeans PR apache/netbeans#7926, to fix the unit test failures in the java.hints module due to old Apple JDK 6 special treatment for the expected output.