### PR TITLE
Relabeled the command "New From Template" to "New File from Template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Java Platform extension from Oracle brings full featured development support (ed
     - For more information, see the section [Selecting the JDK](#selecting-the-jdk).
 4. Use any one of the following ways to start coding, compiling and debugging in Java.
     - Simply create a new Java class with `public static void main(String[] args)` method.
-    - Use the __Java: New File...__ command to create a new Java file.
+    - Use the __Java: New File from Template...__ command to create a new Java file.
     - Use the __Java: New Project...__ command to create a new project.
     - Open the folder with existing __Maven__ or __Gradle__ project files (_pom.xml_ or _build.gradle, gradle.properties_).
 
 ## Supported Actions
 In the VS Code command palette :
 * __Java: New Project...__ allows creation of new Maven or Gradle project 
-* __Java: New File...__ add various files to currently selected open project. Files are:
+* __Java: New File from Template...__ add various files to currently selected open project. Files are:
     * Java - broad selection of various predefined Java classes
     * Unit tests - JUnit and TestNG templates for test suites and test cases
     * Other - various templates for Javascript, JSON, YAML, properties, ... files

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -36,14 +36,14 @@ Java Platform extension from Oracle brings full featured development support (ed
     - For more information, see the section [Selecting the JDK](#selecting-the-jdk).
 4. Use any one of the following ways to start coding, compiling and debugging in Java.
     - Simply create a new Java class with `public static void main(String[] args)` method.
-    - Use the __Java: New File...__ command to create a new Java file.
+    - Use the __Java: New File from Template...__ command to create a new Java file.
     - Use the __Java: New Project...__ command to create a new project.
     - Open the folder with existing __Maven__ or __Gradle__ project files (_pom.xml_ or _build.gradle, gradle.properties_).
 
 ## Supported Actions
 In the VS Code command palette :
 * __Java: New Project...__ allows creation of new Maven or Gradle project 
-* __Java: New File...__ add various files to currently selected open project. Files are:
+* __Java: New File from Template...__ add various files to currently selected open project. Files are:
     * Java - broad selection of various predefined Java classes
     * Unit tests - JUnit and TestNG templates for test suites and test cases
     * Other - various templates for Javascript, JSON, YAML, properties, ... files

--- a/vscode/l10n/bundle.l10n.en.json
+++ b/vscode/l10n/bundle.l10n.en.json
@@ -83,7 +83,7 @@
   "jdk.extension.notInstalled.label":"Extension not installed.",
   "jdk.extension.error_msg.clientNotAvailable":"Client not available",
   "jdk.extension.progressBar.error_msg.cannotRun":"cannot run {lsCommand}; client is {client}",
-  "jdk.extension.error_msg.doesntSupportNewTeamplate":"Client {client} doesn't support creating a new file",
+  "jdk.extension.error_msg.doesntSupportNewTeamplate":"Client {client} doesn't support creating a new file from template",
   "jdk.extension.error_msg.doesntSupportNewProject":"Client {client} doesn't support new project",
   "jdk.extension.error_msg.doesntSupportGoToTest":"Client {client} doesn't support go to test",
   "jdk.extension.error_msg.noSuperImpl":"No super implementation found",

--- a/vscode/l10n/bundle.l10n.ja.json
+++ b/vscode/l10n/bundle.l10n.ja.json
@@ -83,7 +83,7 @@
   "jdk.extension.notInstalled.label":"拡張機能がインストールされませんでした。",
   "jdk.extension.error_msg.clientNotAvailable":"クライアントを使用できません",
   "jdk.extension.progressBar.error_msg.cannotRun":"{lsCommand}を実行できません。クライアントは{client}です",
-  "jdk.extension.error_msg.doesntSupportNewTeamplate":"クライアント{client}では、「ファイル新規作成」はサポートされていません",
+  "jdk.extension.error_msg.doesntSupportNewTeamplate":"クライアント{client}では、「テンプレートからファイル新規作成」はサポートされていません",
   "jdk.extension.error_msg.doesntSupportNewProject":"クライアント{client}では、新規プロジェクトはサポートされていません",
   "jdk.extension.error_msg.doesntSupportGoToTest":"クライアント{client}では、「テストへ移動」はサポートされていません",
   "jdk.extension.error_msg.noSuperImpl":"スーパークラスの実装が見つかりません",

--- a/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/vscode/l10n/bundle.l10n.zh-cn.json
@@ -83,7 +83,7 @@
   "jdk.extension.notInstalled.label":"未安装扩展。",
   "jdk.extension.error_msg.clientNotAvailable":"客户端不可用",
   "jdk.extension.progressBar.error_msg.cannotRun":"无法运行 {lsCommand}；客户端为 {client}",
-  "jdk.extension.error_msg.doesntSupportNewTeamplate":"客户端 {client} 不支持建新文件",
+  "jdk.extension.error_msg.doesntSupportNewTeamplate":"客户端 {client} 不支持从模板新建文件",
   "jdk.extension.error_msg.doesntSupportNewProject":"客户端 {client} 不支持新项目",
   "jdk.extension.error_msg.doesntSupportGoToTest":"客户端 {client} 不支持转至测试",
   "jdk.extension.error_msg.noSuperImpl":"未找到超类实现",

--- a/vscode/package.nls.ja.json
+++ b/vscode/package.nls.ja.json
@@ -3,7 +3,7 @@
     "jdk.views.explorer.projects": "プロジェクト",
     "jdk.workspace.compile": "ワークスペースのコンパイル",
     "jdk.workspace.clean": "ワークスペースの消去",
-    "jdk.workspace.new": "ファイル新規作成...",
+    "jdk.workspace.new": "テンプレートからファイル新規作成...",
     "jdk.workspace.newproject": "新規プロジェクト...",
     "jdk.java.goto.super.implementation": "スーパークラスの実装へ移動",
     "jdk.open.type": "タイプを開く...",

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -3,7 +3,7 @@
     "jdk.views.explorer.projects": "Projects",
     "jdk.workspace.compile": "Compile Workspace",
     "jdk.workspace.clean": "Clean Workspace",
-    "jdk.workspace.new": "New File...",
+    "jdk.workspace.new": "New File from Template...",
     "jdk.workspace.newproject": "New Project...",
     "jdk.java.goto.super.implementation": "Go to Super Implementation",
     "jdk.open.type": "Open Type...",

--- a/vscode/package.nls.zh-cn.json
+++ b/vscode/package.nls.zh-cn.json
@@ -3,7 +3,7 @@
     "jdk.views.explorer.projects": "项目",
     "jdk.workspace.compile": "编译工作区",
     "jdk.workspace.clean": "清除工作区",
-    "jdk.workspace.new": "建新文件...",
+    "jdk.workspace.new": "从模板新建文件...",
     "jdk.workspace.newproject": "新建项目...",
     "jdk.java.goto.super.implementation": "转至超类实现",
     "jdk.open.type": "打开类型...",


### PR DESCRIPTION
In order to improve readability and clarity, changed the label for the command to create a new class/test/interface/exception etc. "New From Template" --> "New File from Template"

Also updated the label references in READMEs, messages and translations.

This also avoids the command "New File" getting repeated twice in the Project explorer panel if it is simplified further as done in PR #302.