### PR TITLE
Fixed broken debugger attach UI options

### DIFF
--- a/vscode/src/commands/commands.ts
+++ b/vscode/src/commands/commands.ts
@@ -46,7 +46,8 @@ export const extCommands = {
     startupCondition: appendPrefixToCommand('startup.condition'),
     nbEventListener: appendPrefixToCommand('addEventListener'),
     selectEditorProjs: appendPrefixToCommand('select.editor.projects'),
-    attachDebugger: appendPrefixToCommand("java.attachDebugger.connector"),
+    attachDebuggerConnector: appendPrefixToCommand("java.attachDebugger.connector"),
+    attachDebuggerConfigurations: appendPrefixToCommand("java.attachDebugger.configurations"),
     loadWorkspaceTests: appendPrefixToCommand("load.workspace.tests"),
     projectDeleteEntry: appendPrefixToCommand("foundProjects.deleteEntry")
 }

--- a/vscode/src/debugger/debugger.ts
+++ b/vscode/src/debugger/debugger.ts
@@ -151,7 +151,7 @@ class NetBeansConfigurationDynamicProvider implements vscode.DebugConfigurationP
             return [];
         }
         let result: vscode.DebugConfiguration[] = [];
-        const attachConnectors: DebugConnector[] | null | undefined = await vscode.commands.executeCommand(extCommands.attachDebugger);
+        const attachConnectors: DebugConnector[] | null | undefined = await vscode.commands.executeCommand(extCommands.attachDebuggerConfigurations);
         if (attachConnectors) {
             for (let ac of attachConnectors) {
                 const debugConfig: vscode.DebugConfiguration = {
@@ -163,7 +163,7 @@ class NetBeansConfigurationDynamicProvider implements vscode.DebugConfigurationP
                     let defaultValue: string = ac.defaultValues[i];
                     if (!defaultValue.startsWith("${command:")) {
                         // Create a command that asks for the argument value:
-                        let cmd: string = `${extCommands.attachDebugger}.${ac.id}.${ac.arguments[i]}`;
+                        let cmd: string = `${extCommands.attachDebuggerConnector}.${ac.id}.${ac.arguments[i]}`;
                         debugConfig[ac.arguments[i]] = "${command:" + cmd + "}";
                         if (!commandValues.has(cmd)) {
                             commandValues.set(cmd, ac.defaultValues[i]);


### PR DESCRIPTION
Attach to port, Attach to process, etc. options available in the Debugger Session seemed to be broken after refactoring the codebase (https://github.com/oracle/javavscode/pull/292).
So, this PR aims to fix the broken configuration.