### PR TITLE
Dependency Upgrade

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -8979,11 +8979,6 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
-lru-cache
--------- Copyrights
-Copyright (c) Isaac Z. Schlueter and Contributors
-
--------- Dependency
 minimatch
 -------- Copyrights
 Copyright (c) Isaac Z. Schlueter and Contributors
@@ -8995,10 +8990,8 @@ Copyright (c) Isaac Z. Schlueter and Contributors
 Copyright Isaac Z. Schlueter
 
 -------- Dependencies Summary
-lru-cache
 minimatch
 semver
-yallist
 
 -------- License used by Dependencies
 SPDX:ISC

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -8861,7 +8861,6 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 =========================================
 END OF minimatch NOTICES AND INFORMATION
------------------- END OF DEPENDENCY LICENCE --------------------
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -8761,12 +8761,14 @@ License Type: MIT
 ------------------ END OF DEPENDENCY LICENCE --------------------
 
 
-Dependency: VSCode Language Server - Node
+Dependency: vscode-languageclient
 =========================================
+------------------ START OF DEPENDENCY LICENSE --------------------
+- vscode-languageclient
 
 Copyright (c) Microsoft Corporation
-
 License: MIT
+
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation files
 (the "Software"), to deal in the Software without restriction, including without
@@ -8783,64 +8785,14 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-vscode-jsonrpc
--------- Copyrights
-Copyright (c) Microsoft Corporation
-Copyright (c) Microsoft Corporation. All rights reserved.
-Copyrights are respective of each contributor listed at the beginning of each definition file.
--------- Notices
-THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
-For Microsoft vscode-jsonrpc
-
-This project incorporates material from the project(s) listed below (collectively, â€œThird Party Codeâ€).
-Microsoft is not the original author of the Third Party Code.  The original copyright notice and license
-under which Microsoft received such Third Party Code are set out below. This Third Party Code is licensed
-to you under their original license terms set forth below.  Microsoft reserves all other rights not expressly
-granted, whether by implication, estoppel or otherwise.
-
-1.       DefinitelyTyped version 0.0.1 (https://github.com/borisyankov/DefinitelyTyped)
-
-This project is licensed under the MIT license.
-Copyrights are respective of each contributor listed at the beginning of each definition file.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
--------- Dependency
-vscode-languageclient
--------- Copyrights
-Copyright (c) Microsoft Corporation
-Copyright (c) Microsoft Corporation. All rights reserved.
-Copyrights are respective of each contributor listed at the beginning of each definition file.
-Copyright (c) Isaac Z. Schlueter and Contributors
--------- Notices
+--------- Notice ---------
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 For Microsoft vscode-languageclient
-
 This project incorporates material from the project(s) listed below (collectively, â€œThird Party Codeâ€).
 Microsoft is not the original author of the Third Party Code.  The original copyright notice and license
 under which Microsoft received such Third Party Code are set out below. This Third Party Code is licensed
 to you under their original license terms set forth below.  Microsoft reserves all other rights not expressly
 granted, whether by implication, estoppel or otherwise.
-
 1. DefinitelyTyped version 0.0.1 (https://github.com/borisyankov/DefinitelyTyped)
 2. semver version 6.3.0 (https://github.com/npm/node-semver)
 3. minimatch version 3.0.4 (https://github.com/isaacs/minimatch)
@@ -8909,7 +8861,47 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 =========================================
 END OF minimatch NOTICES AND INFORMATION
+------------------ END OF DEPENDENCY LICENCE --------------------
 
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+vscode-jsonrpc
+-------- Copyrights
+Copyright (c) Microsoft Corporation
+Copyright (c) Microsoft Corporation. All rights reserved.
+Copyrights are respective of each contributor listed at the beginning of each definition file.
+-------- Notices
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+For Microsoft vscode-jsonrpc
+
+This project incorporates material from the project(s) listed below (collectively, â€œThird Party Codeâ€).
+Microsoft is not the original author of the Third Party Code.  The original copyright notice and license
+under which Microsoft received such Third Party Code are set out below. This Third Party Code is licensed
+to you under their original license terms set forth below.  Microsoft reserves all other rights not expressly
+granted, whether by implication, estoppel or otherwise.
+
+1.       DefinitelyTyped version 0.0.1 (https://github.com/borisyankov/DefinitelyTyped)
+
+This project is licensed under the MIT license.
+Copyrights are respective of each contributor listed at the beginning of each definition file.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 -------- Dependency
 vscode-languageserver-protocol

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "0.1.0",
 			"license": "Apache 2.0",
 			"dependencies": {
-				"@vscode/debugadapter": "^1.65.0",
+				"@vscode/debugadapter": "^1.68.0",
 				"@vscode/l10n": "^0.0.18",
 				"jsonc-parser": "3.3.1",
-				"vscode-languageclient": "^8.1.0"
+				"vscode-languageclient": "^9.0.1"
 			},
 			"devDependencies": {
 				"@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -1080,20 +1080,22 @@
 			"dev": true
 		},
 		"node_modules/@vscode/debugadapter": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.65.0.tgz",
-			"integrity": "sha512-l9jdX0GFoFVAc7O4O8iVnCjO0pgxbx+wJJXCaYSuglGtYwMNcJdc7xm96cuVx4LWzSqneIjvjzbuzZtoVZhZzQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+			"license": "MIT",
 			"dependencies": {
-				"@vscode/debugprotocol": "1.65.0"
+				"@vscode/debugprotocol": "1.68.0"
 			},
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/@vscode/debugprotocol": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.65.0.tgz",
-			"integrity": "sha512-ejerrPMBXzYms6Ks+Gb7cdXtdncmT0xwIKNsc0c/SxhEa0HVY5jdvLUegYE91p7CQJpCnXOD/r2CvViN8txLLA=="
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+			"license": "MIT"
 		},
 		"node_modules/@vscode/l10n": {
 			"version": "0.0.18",
@@ -3788,24 +3790,26 @@
 			"dev": true
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-			"integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-			"integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^5.1.0",
 				"semver": "^7.3.7",
-				"vscode-languageserver-protocol": "3.17.3"
+				"vscode-languageserver-protocol": "3.17.5"
 			},
 			"engines": {
-				"vscode": "^1.67.0"
+				"vscode": "^1.82.0"
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/brace-expansion": {
@@ -3828,18 +3832,20 @@
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-			"integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
 			"dependencies": {
-				"vscode-jsonrpc": "8.1.0",
-				"vscode-languageserver-types": "3.17.3"
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-			"integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
 			"version": "3.0.8",
@@ -4693,17 +4699,17 @@
 			"dev": true
 		},
 		"@vscode/debugadapter": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.65.0.tgz",
-			"integrity": "sha512-l9jdX0GFoFVAc7O4O8iVnCjO0pgxbx+wJJXCaYSuglGtYwMNcJdc7xm96cuVx4LWzSqneIjvjzbuzZtoVZhZzQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
 			"requires": {
-				"@vscode/debugprotocol": "1.65.0"
+				"@vscode/debugprotocol": "1.68.0"
 			}
 		},
 		"@vscode/debugprotocol": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.65.0.tgz",
-			"integrity": "sha512-ejerrPMBXzYms6Ks+Gb7cdXtdncmT0xwIKNsc0c/SxhEa0HVY5jdvLUegYE91p7CQJpCnXOD/r2CvViN8txLLA=="
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
 		},
 		"@vscode/l10n": {
 			"version": "0.0.18",
@@ -6566,18 +6572,18 @@
 			"dev": true
 		},
 		"vscode-jsonrpc": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-			"integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
 		},
 		"vscode-languageclient": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-			"integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
 			"requires": {
 				"minimatch": "^5.1.0",
 				"semver": "^7.3.7",
-				"vscode-languageserver-protocol": "3.17.3"
+				"vscode-languageserver-protocol": "3.17.5"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -6599,18 +6605,18 @@
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-			"integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
 			"requires": {
-				"vscode-jsonrpc": "8.1.0",
-				"vscode-languageserver-types": "3.17.3"
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-			"integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"vscode-uri": {
 			"version": "3.0.8",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -797,9 +797,9 @@
 		"vscode-uri": "^3.0.8"
 	},
 	"dependencies": {
-		"@vscode/debugadapter": "^1.65.0",
+		"@vscode/debugadapter": "^1.68.0",
 		"@vscode/l10n": "^0.0.18",
 		"jsonc-parser": "3.3.1",
-		"vscode-languageclient": "^8.1.0"
+		"vscode-languageclient": "^9.0.1"
 	}
 }


### PR DESCRIPTION
### Changes

1. VSCode Language Server - Node from 8.1.0 → 9.0.1
2. VS Code Debug Protocol and Debug Adapter: 1.65.0 → 1.68.0
3. Removing unnecessary dependancies from 3PLT