### PR TITLE
Added JVM flag to disable JNI use warning with JDK 24.

### DIFF
--- a/vscode/src/lsp/launchOptions.ts
+++ b/vscode/src/lsp/launchOptions.ts
@@ -54,7 +54,8 @@ const extraLaunchOptions = [
     "--locale", l10n.nbLocaleCode(),
     "--start-java-language-server=listen-hash:0",
     "--start-java-debug-adapter-server=listen-hash:0",
-    "-J-DTopSecurityManager.disable=true"
+    "-J-DTopSecurityManager.disable=true",
+    "-J--enable-native-access=ALL-UNNAMED"
 ];
 
 const prepareUserConfigLaunchOptions = (): string[] => {


### PR DESCRIPTION
With reference to [JEP 472](https://openjdk.org/jeps/472) part of JDK 24. By default warnings are issued for use of JNI . Since `nbcode/platform/modules/ext/jna-5.14.0.jar` uses JNI adding JVM flag is necessary to ensure no warnings appear with JDK 24 and with future JDKs it works .

JVM Flag `enable-native-access` support with JDKs
- The flag is officially supported by [JDK 22  Java Command Standard Options section ](https://docs.oracle.com/en/java/javase/22/docs/specs/man/java.html) . 
- Though it was introduced as part of the Foreign Functions and Memory  API when released as incubator feature in JDK 17 [JEP 412](https://openjdk.org/jeps/412)  . 
-  Manually checking with Oracle JDK 17 onwards using `java --help` also shows this flag . 
- This flag is  part of the OpenJDK 17 onwards checked from [JVM Runtime Args JDK 17 ](https://github.com/openjdk/jdk/blob/jdk-17-ga/src/hotspot/share/runtime/arguments.cpp). So most vendors that build on top of OpenJDK should support this from JDK 17 onwards .(Checked corretto it does support this flag from 17 Onwards .)

For Testing 
- Download the latest JDK24-ea build. 
-  Set JDK Home in JSON preferences in vscode .
-  Open Java project and see in the output channel for 'Oracle Java SE Language' no warnings for JNI appear.
- Check that extension features work as it is.
