### PR TITLE
Updated vsix building in order to pass vsixsigntool validation after modified codesigning flow

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,6 +63,7 @@
             patches/8036-draft.diff
             patches/8038-draft.diff
             patches/mvn-sh.diff
+            patches/project-marker-jdk.diff
             patches/generate-dependencies.diff
             patches/rename-debugger.diff
             patches/remove-db.diff
@@ -109,7 +110,11 @@
         <mkdir dir="${lsp.build.dir}/etc" />
         <copy todir="${lsp.build.dir}/etc" file="script/etc/nbcode.conf" overwrite="true" />
         <copy todir="${lsp.build.dir}/etc" file="script/etc/nbcode.clusters" overwrite="true" />
-        <move file="${lsp.build.dir}/java/maven/bin/mvn" tofile="${lsp.build.dir}/java/maven/bin/mvn.sh" />
+        <move file="${lsp.build.dir}/extide/ant/bin/ant" tofile="${lsp.build.dir}/extide/ant/bin/ant.sh"/>
+        <move file="${lsp.build.dir}/extide/ant/bin/antRun" tofile="${lsp.build.dir}/extide/ant/bin/antRun.sh"/>
+        <move file="${lsp.build.dir}/java/maven/bin/mvn" tofile="${lsp.build.dir}/java/maven/bin/mvn.sh"/>
+        <move file="${lsp.build.dir}/java/maven/bin/mvnDebug" tofile="${lsp.build.dir}/java/maven/bin/mvnDebug.sh"/>
+        <move file="${lsp.build.dir}/java/maven/bin/mvnyjp" tofile="${lsp.build.dir}/java/maven/bin/mvnyjp.sh"/>
         <move file="${lsp.build.dir}/bin/nbcode" tofile="${lsp.build.dir}/bin/nbcode.sh" />
         <move file="${lsp.build.dir}/platform/lib/nbexec" tofile="${lsp.build.dir}/platform/lib/nbexec.sh" />
         <replace file="${lsp.build.dir}/bin/nbcode.sh" token="/platform*/lib/nbexec" value="/platform*/lib/nbexec.sh"/>
@@ -118,7 +123,11 @@
         <replace file="${lsp.build.dir}/platform/lib/nbexec64.dll" token="java.security.manager" value="no.java.secur.manager" encoding="ISO-8859-1"/>
         <chmod file="${lsp.build.dir}/bin/nbcode.sh" perm="u+x" />
         <chmod file="${lsp.build.dir}/platform/lib/nbexec.sh" perm="u+x"/>
-        <chmod file="${lsp.build.dir}/java/maven/bin/mvn.sh" perm="u+x" />
+        <chmod file="${lsp.build.dir}/extide/ant/bin/ant.sh" perm="u+x"/>
+        <chmod file="${lsp.build.dir}/extide/ant/bin/antRun.sh" perm="u+x"/>
+        <chmod file="${lsp.build.dir}/java/maven/bin/mvn.sh" perm="u+x"/>
+        <chmod file="${lsp.build.dir}/java/maven/bin/mvnDebug.sh" perm="u+x"/>
+        <chmod file="${lsp.build.dir}/java/maven/bin/mvnyjp.sh" perm="u+x"/>
     </target>
     <target name="add-extra-modules" depends="build-lsp-server,build-l10n-bundles" if="extra.modules">
         <ant dir="../../nbbuild" target="build-nbms" inheritall="false" inheritrefs="false">
@@ -238,14 +247,28 @@
             <arg value="-Dexec.mainClass=org.netbeans.prepare.bundles.PrepareBundles" />
             <arg value="-Dexec.args=${build.dir}/bundles ${nb_all}" />
         </exec>
- 
+
         <mkdir dir="${build.dir}/vsce" />
         <exec executable="npm${cmd.suffix}" failonerror="true" dir="${build.dir}/vsce">
             <arg value="install" />
             <arg value="--save" />
             <arg value="@vscode/vsce@2.19.0" />
         </exec>
-        
+
+        <move todir="${basedir}/vscode/node_modules" includeemptydirs="false">
+            <fileset dir="${basedir}/vscode/node_modules">
+                <include name="**/LICENSE"/>
+                <include name="**/NOTICE"/>
+            </fileset>
+            <mapper type="glob" from="*" to="*.txt"/>
+        </move>
+        <move todir="${basedir}/vscode/nbcode" includeemptydirs="false">
+            <fileset dir="${basedir}/vscode/nbcode">
+                <include name="**/LICENSE"/>
+                <include name="**/NOTICE"/>
+            </fileset>
+            <mapper type="glob" from="*" to="*.txt"/>
+        </move>
         <copy file="${basedir}/LICENSE.txt" todir="${basedir}/vscode" />
         <copy file="${basedir}/THIRD_PARTY_LICENSES.txt" todir="${basedir}/vscode" />
         <copy file="${basedir}/README.md" todir="${basedir}/vscode" />

--- a/build.xml
+++ b/build.xml
@@ -255,6 +255,14 @@
             <arg value="@vscode/vsce@2.19.0" />
         </exec>
 
+        <exec executable="patch" dir="${build.dir}/vsce/node_modules/@vscode/vsce/out" failifexecutionfails="false" failonerror="false">
+            <arg value="-p1"/>
+            <arg value="-z"/>
+            <arg value=".orig"/>
+            <arg value="-i"/>
+            <arg value="${basedir}/patches/vsce-package-ContentTypes.diff"/>
+        </exec>
+
         <move todir="${basedir}/vscode/node_modules" includeemptydirs="false">
             <fileset dir="${basedir}/vscode/node_modules">
                 <include name="**/LICENSE"/>

--- a/patches/project-marker-jdk.diff
+++ b/patches/project-marker-jdk.diff
@@ -1,0 +1,17 @@
+diff --git a/java/java.openjdk.project/licenseinfo.xml b/java/java.openjdk.project/licenseinfo.xml
+index a2c0157ee9..4cb7888b23 100644
+--- a/java/java.openjdk.project/licenseinfo.xml
++++ b/java/java.openjdk.project/licenseinfo.xml
+@@ -27,7 +27,7 @@
+         <file>src/org/netbeans/modules/java/openjdk/project/resources/jdk-project.png</file> <!-- copy of: java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png-->
+         <file>src/org/netbeans/modules/java/openjdk/project/resources/nativeFilesFolderOpened.gif</file> <!-- copy of: openide.loaders/src/org/openide/loaders/defaultFolderOpen.gif-->
+         <file>src/org/netbeans/modules/java/openjdk/project/resources/nativeFilesFolder.gif</file> <!-- copy of: openide.loaders/src/org/openide/loaders/defaultFolder.gif-->
+-        <file>release/patterns/project-marker-jdk</file>
++        <file>release/patterns/project-marker-jdk.txt</file>
+         <license ref="Apache-2.0-ASF" />
+         <comment type="COMMENT_UNSUPPORTED" />
+     </fileset>
+diff --git a/java/java.openjdk.project/release/patterns/project-marker-jdk b/java/java.openjdk.project/release/patterns/project-marker-jdk.txt
+similarity index 100%
+rename from java/java.openjdk.project/release/patterns/project-marker-jdk
+rename to java/java.openjdk.project/release/patterns/project-marker-jdk.txt

--- a/patches/vsce-package-ContentTypes.diff
+++ b/patches/vsce-package-ContentTypes.diff
@@ -1,0 +1,14 @@
+diff --git a/package.js.orig b/package.js
+index 5bc5e0c..4aa4b79 100644
+--- a/package.js.orig
++++ b/package.js
+@@ -1088,7 +1088,8 @@ async function toContentTypes(files) {
+     }
+     const contentTypes = [];
+     for (const [extension, contentType] of mimetypes) {
+-        contentTypes.push(`<Default Extension="${extension}" ContentType="${contentType}"/>`);
++        const extn = (extension.startsWith('.') && extension.length > 1) ? extension.substring(1) : extension;
++        contentTypes.push(`<Default Extension="${extn}" ContentType="${contentType}"/>`);
+     }
+     return `<?xml version="1.0" encoding="utf-8"?>
+ <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${contentTypes.join('')}</Types>

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -13,3 +13,5 @@ coverage/**
 **/.nycrc.json
 esbuild.js
 images/*
+**/.lastModified
+**/.npmignore


### PR DESCRIPTION
The `vsixsigntool` has certain pre-requisites for its verification to pass. These are no longer done in the code-signing flow, requiring them to be performed prior to the creation of the vsix. 

It seems that the VS Code Marketplace publishing uses a different validation flow for signed vsix, since the unsigned vsix created by the [@vscode/vsce](@vscode/vsce) node tool doesn't adhere to these restrictions.
For example:
- `[Content_Types].xml` must contain file-extension strings without a `'.'` prefix in a signed vsix-extension.
- There must be no files present in the vsix-extension without a file-extension.