### PR TITLE
Fixed label and id issue in JDK downloader

### DIFF
--- a/vscode/l10n/bundle.l10n.en.json
+++ b/vscode/l10n/bundle.l10n.en.json
@@ -3,6 +3,8 @@
   "jdk.downloader.html.details":"<p>This tool enables you to download either the latest Oracle Java SE JDK with <a href='https://www.java.com/freeuselicense'>Oracle No-Fee Terms and Conditions</a> or the Oracle OpenJDK builds under the <a href='https://openjdk.org/legal/gplv2+ce.html'>GNU Public License with ClassPath Exception</a></p> <p>It will then handle the installation and configuration on your behalf.</p> <p>This enables you to take full advantage of all the features offered by this extension.</p>",
   "jdk.downloader.button.label.oracleJdk": "Download Oracle Java SE JDK",
   "jdk.downloader.label.or": "or",
+  "jdk.downloader.label.openJdk": "OpenJDK",
+  "jdk.downloader.label.oracleJdk": "Oracle JDK",
   "jdk.downloader.button.label.openJdk": "Download Oracle OpenJDK",
   "jdk.downloader.button.label.selectJdkFromSystem": "Select installed JDK from my system",
   "jdk.downloader.label.selectOracleJdkVersion": "Select Oracle Java SE Version",

--- a/vscode/l10n/bundle.l10n.ja.json
+++ b/vscode/l10n/bundle.l10n.ja.json
@@ -3,6 +3,8 @@
   "jdk.downloader.html.details":"<p>このツールは、<a href='https://www.java.com/freeuselicense'>Oracle No-Fee Terms and Conditions</a>の最新のOracle Java SE JDKまたは、<a href='https://openjdk.org/legal/gplv2+ce.html'>クラスパス例外付きGNU Public License</a>に基づいたOracle OpenJDKビルドのいずれかをダウンロードできます</p> <p>次に、インストールおよび構成をかわりに処理します。</p> <p>これにより、この拡張によって提供されたすべての機能を最大限活用できます。</p>",
   "jdk.downloader.button.label.oracleJdk": "Oracle Java SE JDKのダウンロード",
   "jdk.downloader.label.or": "または",
+  "jdk.downloader.label.openJdk": "OpenJDK",
+  "jdk.downloader.label.oracleJdk": "Oracle JDK",
   "jdk.downloader.button.label.openJdk": "Oracle OpenJDKのダウンロード",
   "jdk.downloader.button.label.selectJdkFromSystem": "システムからインストール済JDKの選択",
   "jdk.downloader.label.selectOracleJdkVersion": "Oracle Java SEバージョンの選択",

--- a/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/vscode/l10n/bundle.l10n.zh-cn.json
@@ -3,6 +3,8 @@
   "jdk.downloader.html.details":"<p>使用此工具，您可以遵循 <a href='https://www.java.com/freeuselicense'>Oracle 免费条款和条件</a>下载最新的 Oracle Java SE JDK，或者依照 <a href='https://openjdk.org/legal/gplv2+ce.html'>GNU 公共许可证（包含 ClassPath 例外条款）</a>下载 Oracle OpenJDK 构建</p> <p>之后，它将代表您处理安装和配置。</p> <p>这样，您可以充分利用此扩展提供的所有功能。</p>",
   "jdk.downloader.button.label.oracleJdk": "下载 Oracle Java SE JDK",
   "jdk.downloader.label.or": "或",
+  "jdk.downloader.label.openJdk": "OpenJDK",
+  "jdk.downloader.label.oracleJdk": "Oracle JDK",
   "jdk.downloader.button.label.openJdk": "下载 Oracle OpenJDK",
   "jdk.downloader.button.label.selectJdkFromSystem": "从我的系统选择安装的 JDK",
   "jdk.downloader.label.selectOracleJdkVersion": "选择 Oracle Java SE 版本",

--- a/vscode/src/webviews/jdkDownloader/action.ts
+++ b/vscode/src/webviews/jdkDownloader/action.ts
@@ -49,7 +49,7 @@ export class JdkDownloaderAction {
 
     public attachListener = async (message: any) => {
         const { command, id, jdkVersion, jdkOS, jdkArch, installType } = message;
-        if (command === JdkDownloaderView.DOWNLOAD_CMD_LABEL) {
+        if (command === JdkDownloaderView.DOWNLOAD_CMD) {
             LOGGER.log(`Request received for downloading ${id} version ${jdkVersion}`);
 
             this.jdkType = id;
@@ -160,10 +160,10 @@ export class JdkDownloaderAction {
     private generateDownloadUrl = (): string => {
         let baseDownloadUrl: string = '';
 
-        if (this.jdkType === JdkDownloaderView.OPEN_JDK_LABEL) {
+        if (this.jdkType === JdkDownloaderView.JDK_TYPE.openJdk) {
             baseDownloadUrl = `${jdkDownloaderConstants.OPEN_JDK_VERSION_DOWNLOAD_LINKS[`${this.jdkVersion}`]}_${this.osType!.toLowerCase()}-${this.machineArch}_bin`;
         }
-        else if (this.jdkType === JdkDownloaderView.ORACLE_JDK_LABEL) {
+        else if (this.jdkType === JdkDownloaderView.JDK_TYPE.oracleJdk) {
             baseDownloadUrl = `${jdkDownloaderConstants.ORACLE_JDK_BASE_DOWNLOAD_URL}/${this.jdkVersion}/latest/jdk-${this.jdkVersion}_${this.osType!.toLowerCase()}-${this.machineArch}_bin`;
         }
         const downloadUrl = this.osType === 'windows' ? `${baseDownloadUrl}.zip` : `${baseDownloadUrl}.tar.gz`;

--- a/vscode/src/webviews/jdkDownloader/view.ts
+++ b/vscode/src/webviews/jdkDownloader/view.ts
@@ -23,9 +23,14 @@ import { l10n } from '../../localiser';
 import { LOGGER } from '../../logger';
 
 export class JdkDownloaderView {
-    public static readonly OPEN_JDK_LABEL = "OpenJDK";
-    public static readonly ORACLE_JDK_LABEL = "Oracle JDK";
-    public static readonly DOWNLOAD_CMD_LABEL = 'downloadJDK';
+    public static readonly DOWNLOAD_CMD = 'downloadJDK';
+    public static readonly JDK_TYPE = {
+        oracleJdk: "oracleJdk",
+        openJdk: "openJdk",
+    }
+
+    private static readonly OPEN_JDK_LABEL = l10n.value("jdk.downloader.label.openJdk");
+    private static readonly ORACLE_JDK_LABEL = l10n.value("jdk.downloader.label.oracleJdk");
     private readonly jdkDownloaderTitle = l10n.value("jdk.downloader.heading");
 
     private jdkDownloaderWebView?: WebviewPanel;
@@ -222,7 +227,7 @@ export class JdkDownloaderView {
 
                 document.getElementById("addJDKPathManually")?.addEventListener('click', event => {
                     vscode.postMessage({
-                        command: "${JdkDownloaderView.DOWNLOAD_CMD_LABEL}",
+                        command: "${JdkDownloaderView.DOWNLOAD_CMD}",
                         installType: "${JdkDownloaderAction.MANUAL_INSTALLATION_TYPE}",
                     });
                 });
@@ -276,9 +281,9 @@ export class JdkDownloaderView {
 
                 const triggerJDKDownload = (e) => {
                     const { id } = e.target;
-                    const jdkType = id === openJdkButtonId+'DownloadButton' ? "${JdkDownloaderView.OPEN_JDK_LABEL}" : "${JdkDownloaderView.ORACLE_JDK_LABEL}";
+                    const jdkType = id === openJdkButtonId+'DownloadButton' ? "${JdkDownloaderView.JDK_TYPE.openJdk}" : "${JdkDownloaderView.JDK_TYPE.oracleJdk}";
                     vscode.postMessage({
-                        command: "${JdkDownloaderView.DOWNLOAD_CMD_LABEL}",
+                        command: "${JdkDownloaderView.DOWNLOAD_CMD}",
                         id: jdkType,
                         installType: "${JdkDownloaderAction.AUTO_INSTALLATION_TYPE}",
                         jdkVersion: document.getElementById(activeButton.id+'VersionDropdown').value,


### PR DESCRIPTION
- Label constant was being used as id in JDK downloader which can be a issue if labels are localised. 
- So, separated out labels and Ids so that localisation doesn't affect the Id creation.