### PR TITLE
Temporarily disable the error notifier running after indexing.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -56,6 +56,7 @@
             patches/8260.diff
             patches/8280.diff
             patches/8289.diff
+            patches/disable-error-notification.diff
             patches/mvn-sh.diff
             patches/project-marker-jdk.diff
             patches/generate-dependencies.diff

--- a/patches/disable-error-notification.diff
+++ b/patches/disable-error-notification.diff
@@ -1,0 +1,12 @@
+diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java
+index c79de141f6..4bef234b0e 100644
+--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java
++++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java
+@@ -50,6 +50,7 @@ public final class ErrorsNotifier {
+     }
+ 
+     public void notifyErrors(URL root) {
++        if (true) return ; //disable the error notification for now
+         List<LspServerState> toRemove = new ArrayList<>();
+         List<LspServerState> toProcess = new ArrayList<>();
+         synchronized (servers) {


### PR DESCRIPTION
This (NetBeans) patch:
https://github.com/apache/netbeans/commit/0d6fb1ad037ba2a3d332b96c5a4393fb98f4debf
introduced a new feature, where errors for all files are reported from the LSP server to the client when indexing finishes.

But, it does so by taking the list of files with errors, and re-running the diagnostic task on them. When there are many files with errors, this may get very slow.

This PR speeds the process significantly, by reusing errors collected during indexing:
https://github.com/apache/netbeans/pull/8206

but that patch could use some baking time, to see if there are any issues with it.

Hence here, I propose to disable the error publication after indexing for now. Note that if the file is opened in the editor, the errors should be published normally as before. The effect of this PR is that the behavior should be the same as in previous versions of this extension (before the NetBeans 25 upgrade).
