### PR TITLE
Updated OpenJDK CPU release download url

### DIFF
--- a/vscode/src/constants.ts
+++ b/vscode/src/constants.ts
@@ -34,7 +34,7 @@ export namespace jdkDownloaderConstants {
   export const ORACLE_JDK_FALLBACK_VESIONS = ['24', '21'];
   
   export const OPEN_JDK_VERSION_DOWNLOAD_LINKS: { [key: string]: string } = {
-    "24": "https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8ca828c504ffae90/36/GPL/openjdk-24"
+    "24": "https://download.java.net/java/GA/jdk24.0.1/24a58e0e276943138bf3e963e6291ac2/9/GPL/openjdk-24.0.1"
   };  
 }
 


### PR DESCRIPTION
Updated OpenJDK download url to 24.0.1