### PR TITLE
Updated test timeouts and improved maintainability of them

### DIFF
--- a/vscode/src/test/integration/suite/general/explorer.test.ts
+++ b/vscode/src/test/integration/suite/general/explorer.test.ts
@@ -35,5 +35,5 @@ suite('Explorer Test Suite', () => {
         const lvp = await myExplorer.createViewProvider(await awaitClient(), 'foundProjects');
         const firstLevelChildren = await (lvp.getChildren() as Thenable<any[]>);
         assert.strictEqual(firstLevelChildren.length, 0, "No child under the root");
-    }).timeout(60000);
+    });
 });

--- a/vscode/src/test/integration/suite/general/extension.test.ts
+++ b/vscode/src/test/integration/suite/general/extension.test.ts
@@ -40,7 +40,7 @@ suite('Extension Test Suite', function () {
   // Create project which used be used for testing
   this.beforeAll(async () => {
     await prepareProject(filePaths);
-  }).timeout(60000);
+  });
 
   // This test must be run first, in order to activate the extension and wait for the activation to complete
   test("Extension loaded and activated", async () => {
@@ -59,7 +59,7 @@ suite('Extension Test Suite', function () {
     }
     assert.ok(cannotReassignVersion, "Cannot reassign value of version");
 
-  }).timeout(60000);
+  });
 
   // Test if clusters are loaded or not
   test('Find clusters', async () => {
@@ -93,7 +93,7 @@ suite('Extension Test Suite', function () {
     for (let c of found) {
       assert.ok(c.startsWith(nbcode.extensionPath), `All extensions are below ${nbcode.extensionPath}, but: ${c}`);
     }
-  }).timeout(60000);
+  });
 
   // Check if Jdk commands have been loaded
   test("Jdk commands loaded", async () => {
@@ -107,7 +107,7 @@ suite('Extension Test Suite', function () {
     }
 
     assert.ok(containsJdkCommands, "No Jdk command has been loaded");
-  }).timeout(60000);
+  });
 
   // Check if format document command is executed successfully
   test("Format document", async () => {
@@ -118,7 +118,7 @@ suite('Extension Test Suite', function () {
     const unformattedCode = SAMPLE_CODE_FORMAT_DOCUMENT.split('\n').length;
     const isDocumentFormatted = formattedCode > unformattedCode;
     assert.ok(isDocumentFormatted, "document is not formatted");
-  }).timeout(60000);
+  });
 
   // Check if imports are getting sorted on saving document
   test("Sort imports", async () => {
@@ -133,7 +133,7 @@ suite('Extension Test Suite', function () {
       savedCode.indexOf('import java.util.ArrayList;');
     assert.ok(isImportsSorted, "Imports are not sorted");
 
-  }).timeout(60000);
+  });
 
   // Check if unused imports are getting removed on saving document
   test("Remove unused imports", async () => {
@@ -148,7 +148,7 @@ suite('Extension Test Suite', function () {
       savedCode.indexOf('import java.lang.Integer;') === -1;
     assert.ok(areUnusedImportsRemoved, "Unused imports are not removed");
 
-  }).timeout(60000);
+  });
 
   // Check if refactor actions are getting showing on UI and if they are working
   test("Refactor actions executing", async () => {
@@ -176,7 +176,7 @@ suite('Extension Test Suite', function () {
         }
       }
     }
-  }).timeout(60000);
+  });
 
   // Tests explorer is loading properly
   test("Test Explorer tests", async () => {
@@ -203,7 +203,7 @@ suite('Extension Test Suite', function () {
       dumpJava();
       throw error;
     }
-  }).timeout(60000);
+  });
 
   // Check if compile workspace command is excuted succesfully
   test("Compile workspace", async () => {
@@ -221,7 +221,7 @@ suite('Extension Test Suite', function () {
       const item = await (lvp.getTreeItem(firstLevelChildren[0]) as Thenable<TreeItem>);
       assert.strictEqual(item?.label, "basicapp", "Element is named as the Maven project");
     });
-  }).timeout(60000);
+  });
 
   // Get Project info
   test("Get project sources, classpath, and packages", async () => {
@@ -286,7 +286,7 @@ suite('Extension Test Suite', function () {
       dumpJava();
       throw error;
     }
-  }).timeout(60000);
+  });
 
   // Check if clean workspace command is excuted succesfully
   test("Clean workspace", async () => {
@@ -296,7 +296,7 @@ suite('Extension Test Suite', function () {
 
     const mainClass = path.join(folder, 'target');
     assert.ok(!fs.existsSync(mainClass), "Class created by compilation: " + mainClass);
-  }).timeout(60000);
+  });
 
   // Check if xml document formatting is executed successfully
   test("XML Format document", async () => {
@@ -305,6 +305,6 @@ suite('Extension Test Suite', function () {
 
     const formattedContents = editor.document.getText().trim();
     assert.ok(formattedContents == FORMATTED_POM_XML.trim(), "pom.xml is not formatted");
-  }).timeout(60000);
+  });
 
 });

--- a/vscode/src/test/integration/suite/gradle/extension.test.ts
+++ b/vscode/src/test/integration/suite/gradle/extension.test.ts
@@ -58,7 +58,7 @@ suite("Extension gradle tests", function () {
       dumpJava();
       throw error;
     }
-  }).timeout(120*1000);
+  });
 
   // Check if clean workspace command is excuted succesfully
   test("Clean workspace - Gradle", async () => {
@@ -71,5 +71,5 @@ suite("Extension gradle tests", function () {
       !fs.existsSync(mainClass),
       "Class created by compilation: " + mainClass
     );
-  }).timeout(60000);
+  });
 });

--- a/vscode/src/test/integration/suite/localisation/extension.test.ts
+++ b/vscode/src/test/integration/suite/localisation/extension.test.ts
@@ -45,7 +45,7 @@ suite("Extension localisation tests", function () {
             assert.ok(matchKeys(enBundlePath, langBundlePath), `Keys of ${DEFAULT_BUNDLE_FILE_NAME} and  bundle.l10n.${lang}.json don't match`);
             assert.ok(matchValuesTemplate(enBundlePath, langBundlePath), `Value templates don't match for of the keys of ${DEFAULT_BUNDLE_FILE_NAME} and  bundle.l10n.${lang}.json `);
         }
-    }).timeout(60000);
+    });
 
     test("Consistency of keys across package.nls.lang.json files for supported languages", async () => {
         const extension = extensions.getExtension(EXTENSION_NAME);
@@ -57,7 +57,7 @@ suite("Extension localisation tests", function () {
             assert.ok(fs.existsSync(langPackagePath), `package.nls.${lang}.json doesn't exists`);
             assert.ok(matchKeys(enPackagePath, langPackagePath), `Keys of ${DEFAULT_PACKAGE_FILE_NAME} and  package.nls.${lang}.json don't match`);
         }
-    }).timeout(60000);
+    });
 
     // Check localisable fields being appropriately localised for the contributes defined in package.json
     test("Localisable fields in package.json localised properly ", async () => {
@@ -74,7 +74,7 @@ suite("Extension localisation tests", function () {
         assert.ok(checkViewsLocalisation(contributes.views, validKeys), "Error some views is not localized");
         assert.ok(checkDebuggersLocalisation(contributes.debuggers, validKeys), "Error some debugger labels not localized");
         assert.ok(checkConfigurationLocalisation(contributes.configuration, validKeys), "Error some configuration labels not localized");
-    }).timeout(60000);
+    });
 
 
     // Check if l10n.value is called with a valid key and the placeholder map has all the keys as required in the string template 
@@ -86,6 +86,6 @@ suite("Extension localisation tests", function () {
         assert(enBundlePath, `${DEFAULT_BUNDLE_FILE_NAME} not found`);
         const validKeyValues = JSON.parse(fs.readFileSync(enBundlePath, 'utf8'));
         assert(checkL10nUsageInFiles(path.join(extension.extensionPath, "out"), ignoredDirEntriesNames, validKeyValues) === 0, "Some files have invalid localisation keys used. Check the logs or error messages");
-    }).timeout(60000);
+    });
 
 });

--- a/vscode/src/test/integration/testutils.ts
+++ b/vscode/src/test/integration/testutils.ts
@@ -303,7 +303,7 @@ export function runTestSuite(folder: string): Promise<void> {
 	const mocha = new Mocha({
 		ui: 'tdd',
 		color: true,
-		timeout: 10*1000*60
+		timeout: '10m'
 	});
 
 	const testsRoot = path.resolve(folder);


### PR DESCRIPTION
Removed individual tests timeouts and shifted to a single place so that it is easy to maintain and also changed from `milliseconds` to `string` for better readability