### PR TITLE
Updated telemetry jdk-features cache expiry time and maintenance as a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .DS_STORE
+.vscode/
 .idea/
 *.iml
 /nbcode/l10n/locale_ja/release/


### PR DESCRIPTION
- Updated telemetry jdk-features cache expiry default time to 12 hours instead of 1 hour. 
- Also, updated the jdk-features cache maintenance as a union across the source root instead of only those in the active editor.
- Added .vscode/ to gitignore