### PR TITLE
Updated messages for the minimum version of JDK to 24 for disabling nb-javac

### DIFF
--- a/vscode/l10n/bundle.l10n.en.json
+++ b/vscode/l10n/bundle.l10n.en.json
@@ -63,7 +63,7 @@
   "jdk.extension.lspServer.message.noJdkFound": "No JDK found!",
   "jdk.extension.lspServer.label.downloadAndSetup": "Download JDK and setup automatically",
   "jdk.extension.lspServer.error_message": "Error initializing {reason}",
-  "jdk.extension.nbjavac.message.supportedVersionRequired": "Supported version of javac needed. Please either enable the nb-javac library, or use JDK 23+",
+  "jdk.extension.nbjavac.message.supportedVersionRequired": "Supported version of javac needed. Please either enable the nb-javac library, or use JDK 24+",
   "jdk.extension.nbjavac.label.enableNbjavac": "Enable the nb-javac library",
   "jdk.extension.nbjavac.label.openSettings": "Open settings",
   "jdk.extension.javaSupport.label.installGpl": "Install GPLv2+CPEx code",

--- a/vscode/l10n/bundle.l10n.ja.json
+++ b/vscode/l10n/bundle.l10n.ja.json
@@ -63,7 +63,7 @@
   "jdk.extension.lspServer.message.noJdkFound": "JDKが見つかりません!",
   "jdk.extension.lspServer.label.downloadAndSetup": "JDKをダウンロードして自動的に設定",
   "jdk.extension.lspServer.error_message": "初期化中にエラーが発生しました {reason}",
-  "jdk.extension.nbjavac.message.supportedVersionRequired": "サポートされているバージョンのjavacが必要です。nb-javacライブラリを有効にするか、JDK 23+を使用してください",
+  "jdk.extension.nbjavac.message.supportedVersionRequired": "サポートされているバージョンのjavacが必要です。nb-javacライブラリを有効にするか、JDK 24+を使用してください",
   "jdk.extension.nbjavac.label.enableNbjavac": "nb-javacライブラリの有効化",
   "jdk.extension.nbjavac.label.openSettings": "設定を開く",
   "jdk.extension.javaSupport.label.installGpl": "GPLv2+CPExコードのインストール",

--- a/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/vscode/l10n/bundle.l10n.zh-cn.json
@@ -63,7 +63,7 @@
   "jdk.extension.lspServer.message.noJdkFound": "未找到 JDK！",
   "jdk.extension.lspServer.label.downloadAndSetup": "自动下载 JDK 并进行设置",
   "jdk.extension.lspServer.error_message": "初始化时出错：{reason}",
-  "jdk.extension.nbjavac.message.supportedVersionRequired": "需要支持的 javac 版本。请启用 nb-javac 库或使用 JDK 23+",
+  "jdk.extension.nbjavac.message.supportedVersionRequired": "需要支持的 javac 版本。请启用 nb-javac 库或使用 JDK 24+",
   "jdk.extension.nbjavac.label.enableNbjavac": "启用 nb-javac 库",
   "jdk.extension.nbjavac.label.openSettings": "打开设置",
   "jdk.extension.javaSupport.label.installGpl": "安装 GPLv2+CPEx 代码",

--- a/vscode/package.nls.ja.json
+++ b/vscode/package.nls.ja.json
@@ -44,7 +44,7 @@
     "jdk.configuration.serverVmOptions.description": "Java言語サーバーの起動に使用されるその他のVM引数を指定します",
     "jdk.configuration.runConfig.env.description": "環境変数",
     "jdk.configuration.runConfig.cwd.description": "作業ディレクトリ",
-    "jdk.configuration.disableNbJavac.description": "拡張オプション: nb-javacライブラリを無効化すると、選択したJDKからのjavacが使用されます。選択したJDKは少なくともJDK 23である必要があります。",
+    "jdk.configuration.disableNbJavac.description": "拡張オプション: nb-javacライブラリを無効化すると、選択したJDKからのjavacが使用されます。選択したJDKは少なくともJDK 24である必要があります。",
     "jdk.configuration.disableProjectSearchLimit.description": "拡張オプション: プロジェクト情報が含まれているフォルダの検索に対する制限を無効化します。",
     "jdk.debugger.configuration.mainClass.markdownDescription": "Main class specification. Supported formats:\n - an absolute path\n - a path relative to any of the workspace folders\n - a fully qualified name of a class.",
     "jdk.debugger.configuration.classPaths.description": "JVMの起動のためのクラスパス。",

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -44,7 +44,7 @@
     "jdk.configuration.serverVmOptions.description": "Specifies extra VM arguments used to launch the Java Language Server",
     "jdk.configuration.runConfig.env.description": "Environment variables",
     "jdk.configuration.runConfig.cwd.description": "Working directory",
-    "jdk.configuration.disableNbJavac.description": "Advanced option: disable nb-javac library, javac from the selected JDK will be used. The selected JDK must be at least JDK 23.",
+    "jdk.configuration.disableNbJavac.description": "Advanced option: disable nb-javac library, javac from the selected JDK will be used. The selected JDK must be at least JDK 24.",
     "jdk.configuration.disableProjectSearchLimit.description": "Advanced option: disable limits on searching in containing folders for project information.",
     "jdk.debugger.configuration.mainClass.markdownDescription": "Main class specification. Supported formats:\n - an absolute path\n - a path relative to any of the workspace folders\n - a fully qualified name of a class.",
     "jdk.debugger.configuration.classPaths.description": "The classpaths for launching the JVM.",

--- a/vscode/package.nls.zh-cn.json
+++ b/vscode/package.nls.zh-cn.json
@@ -44,7 +44,7 @@
     "jdk.configuration.serverVmOptions.description": "指定用于启动 Java Language Server 的额外 VM 参数",
     "jdk.configuration.runConfig.env.description": "环境变量",
     "jdk.configuration.runConfig.cwd.description": "工作目录",
-    "jdk.configuration.disableNbJavac.description": "高级选项：禁用 nb-javac 库，将使用来自所选 JDK 的 javac。所选 JDK 必须至少为 JDK 23。",
+    "jdk.configuration.disableNbJavac.description": "高级选项：禁用 nb-javac 库，将使用来自所选 JDK 的 javac。所选 JDK 必须至少为 JDK 24。",
     "jdk.configuration.disableProjectSearchLimit.description": "高级选项：禁用在包含项目信息的文件夹中搜索的限制。",
     "jdk.debugger.configuration.mainClass.markdownDescription": "Main class specification. Supported formats:\n - an absolute path\n - a path relative to any of the workspace folders\n - a fully qualified name of a class.",
     "jdk.debugger.configuration.classPaths.description": "用于启动 JVM 的类路径。",


### PR DESCRIPTION
The NB25 backend includes version 24 for nb-javac. The settings for disabling nb-javac (and error messages) are updated to inform that javac from JDK24+ is needed then.