### PR TITLE
Patch to fix the single source file refactoring code actions issue.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,6 +57,7 @@
             patches/8280.diff
             patches/8289.diff
             patches/7893-draft.diff
+            patches/8442-draft.diff
             patches/disable-error-notification.diff
             patches/mvn-sh.diff
             patches/project-marker-jdk.diff

--- a/patches/8442-draft.diff
+++ b/patches/8442-draft.diff
@@ -1,0 +1,13 @@
+diff --git a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
+index ae5f7fd6f8..db0dadefb1 100644
+--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
++++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
+@@ -305,7 +305,7 @@ public class RefactoringUtils {
+     public static boolean isOnSourceClasspath(FileObject fo) {
+         Project pr = FileOwnerQuery.getOwner(fo);
+         if (pr == null) {
+-            return false;
++            return SourceLauncher.isSourceLauncherFile(fo);
+         }
+ 
+         //workaround for 143542


### PR DESCRIPTION
Any java file not part of a project didn't have any code refactoring available as in the code they were marked as not refactorable . This fixes the issue my considering java files not part of project as refactorable
Netbeans PR [#8442](https://github.com/apache/netbeans/pull/8442)
