### PR TITLE
Handling class cast exception while opening pom.xml file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,6 +58,7 @@
             patches/8289.diff
             patches/7893-draft.diff
             patches/8442-draft.diff
+            patches/8460-draft.diff
             patches/disable-error-notification.diff
             patches/mvn-sh.diff
             patches/project-marker-jdk.diff

--- a/patches/8460-draft.diff
+++ b/patches/8460-draft.diff
@@ -1,0 +1,22 @@
+--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenPOMParser.java
++++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenPOMParser.java
+@@ -23,6 +23,7 @@
+ import java.util.prefs.PreferenceChangeListener;
+ import java.util.prefs.Preferences;
+ import javax.swing.event.ChangeListener;
++import javax.swing.text.Document;
+ import org.netbeans.api.editor.mimelookup.MimeRegistration;
+ import org.netbeans.editor.BaseDocument;
+ import org.netbeans.modules.maven.embedder.EmbedderFactory;
+@@ -76,9 +77,9 @@
+             return;
+         }
+         //#236116 passing document protects from looking it up later and causing a deadlock.
+-        final BaseDocument document = (BaseDocument)snapshot.getSource().getDocument(false);
++        final Document document = snapshot.getSource().getDocument(false);
+         final DataObject d = sFile.getLookup().lookup(DataObject.class);
+-        ModelSource ms = Utilities.createModelSource(sFile, d, document);
++        ModelSource ms = Utilities.createModelSource(sFile, d, document instanceof BaseDocument bd ? bd : null);
+         synchronized (this) {
+             theModel = POMModelFactory.getDefault().getModel(ms);
+             lastSnapshot = snapshot;


### PR DESCRIPTION
Backport patch from netbeans which handles class cast exception while opening pom.xml in a better way.
For more info: https://github.com/apache/netbeans/pull/8460