### PR TITLE
added user configuration for setting up code completion commit characters

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -71,6 +71,7 @@
             patches/dev-dependency-licenses.diff
             patches/nb-telemetry.diff
             patches/change-method-parameters-refactoring-qualified-names.diff
+            patches/javavscode-375.diff
         </string>
         <filterchain>
             <tokenfilter delimoutput=" ">

--- a/patches/javavscode-375.diff
+++ b/patches/javavscode-375.diff
@@ -1,0 +1,62 @@
+--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
++++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+@@ -19,6 +19,7 @@
+ package org.netbeans.modules.java.lsp.server.protocol;
+ 
+ import com.google.gson.Gson;
++import com.google.gson.JsonArray;
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonObject;
+ import com.google.gson.JsonPrimitive;
+@@ -292,6 +293,8 @@
+     private static final String NETBEANS_JAVADOC_LOAD_TIMEOUT = "javadoc.load.timeout";// NOI18N
+     private static final String NETBEANS_COMPLETION_WARNING_TIME = "completion.warning.time";// NOI18N
+     private static final String NETBEANS_JAVA_ON_SAVE_ORGANIZE_IMPORTS = "java.onSave.organizeImports";// NOI18N
++    private static final String NETBEANS_CODE_COMPLETION_COMMIT_CHARS = "java.completion.commit.chars";// NOI18N
++
+     private static final String URL = "url";// NOI18N
+     private static final String INDEX = "index";// NOI18N
+     
+@@ -368,6 +371,7 @@
+         AtomicReference<Sampler> samplerRef = new AtomicReference<>();
+         AtomicLong samplingStart = new AtomicLong();
+         AtomicLong samplingWarningLength = new AtomicLong(DEFAULT_COMPLETION_WARNING_LENGTH);
++        AtomicReference<List<String>> codeCompletionCommitChars = new AtomicReference<>(List.of());
+         long completionStart = System.currentTimeMillis();
+         COMPLETION_SAMPLER_WORKER.post(() -> {
+             if (!done.get()) {
+@@ -412,7 +416,10 @@
+             ConfigurationItem completionWarningLength = new ConfigurationItem();
+             completionWarningLength.setScopeUri(uri);
+             completionWarningLength.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_COMPLETION_WARNING_TIME);
+-            return client.configuration(new ConfigurationParams(Arrays.asList(conf, completionWarningLength))).thenApply(c -> {
++            ConfigurationItem commitCharacterConfig = new ConfigurationItem();
++            commitCharacterConfig.setScopeUri(uri);
++            commitCharacterConfig.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_CODE_COMPLETION_COMMIT_CHARS);
++            return client.configuration(new ConfigurationParams(Arrays.asList(conf, completionWarningLength, commitCharacterConfig))).thenApply(c -> {
+                 if (c != null && !c.isEmpty()) {
+                     if (c.get(0) instanceof JsonPrimitive) {
+                         JsonPrimitive javadocTimeSetting = (JsonPrimitive) c.get(0);
+@@ -424,7 +431,11 @@
+ 
+                         samplingWarningLength.set(samplingWarningsLengthSetting.getAsLong());
+                     }
++                    if(c.get(2) instanceof JsonArray){
++                        JsonArray commitCharsJsonArray = (JsonArray) c.get(2);
++                        codeCompletionCommitChars.set(commitCharsJsonArray.asList().stream().map(ch -> ch.toString()).collect(Collectors.toList()));
+                 }
++                }
+                 final int caret = Utils.getOffset(doc, params.getPosition());
+                 List<CompletionItem> items = new ArrayList<>();
+                 Completion.Context context = params.getContext() != null
+@@ -486,8 +497,8 @@
+                                 }).collect(Collectors.toList()));
+                             }
+                         }
+-                        if (completion.getCommitCharacters() != null) {
+-                            item.setCommitCharacters(completion.getCommitCharacters().stream().map(ch -> ch.toString()).collect(Collectors.toList()));
++                        if (codeCompletionCommitChars.get() != null) {
++                            item.setCommitCharacters(codeCompletionCommitChars.get());
+                         }
+                         lastCompletions.add(completion);
+                         item.setData(new CompletionData(uri, index.getAndIncrement()));

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -250,6 +250,11 @@
 					"tags": [
                         "telemetry"
           			]
+				},
+				"jdk.java.completion.commit.chars": {
+					"type": "array",
+					"default": [],
+					"description": "%jdk.configuration.java.completion.commit.chars%"
 				}
 			}
 		},

--- a/vscode/package.nls.ja.json
+++ b/vscode/package.nls.ja.json
@@ -64,6 +64,7 @@
     "jdk.debugger.configuration.attach.listen.description": "接続するデバッグ対象をリスニング",
     "jdk.debugger.configuration.attach.timeout.description": "接続を待つ間のタイムアウト",
     "jdk.debugger.configuration.completion.warning.time.description": "When code completion takes longer than this specified time (in milliseconds), there will be a warning produced (-1 to disable)",
+    "jdk.configuration.java.completion.commit.chars": "Specifies the characters that trigger accepting a code completion suggestion. For example, to accept suggestions when typing a dot (.), set this to [\".\"]",
     "jdk.initialConfigurations.launchJavaApp.name": "Javaアプリケーションの起動",
     "jdk.configurationSnippets.name": "Javaアプリケーションの起動",
     "jdk.configurationSnippets.label": "Java+: Javaアプリケーションの起動",

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -64,6 +64,7 @@
     "jdk.debugger.configuration.attach.listen.description": "Listen for the debuggee to attach",
     "jdk.debugger.configuration.attach.timeout.description": "Timeout while waiting to attach",
     "jdk.debugger.configuration.completion.warning.time.description": "When code completion takes longer than this specified time (in milliseconds), there will be a warning produced (-1 to disable)",
+    "jdk.configuration.java.completion.commit.chars": "Specifies the characters that trigger accepting a code completion suggestion. For example, to accept suggestions when typing a dot (.), set this to [\".\"]",
     "jdk.initialConfigurations.launchJavaApp.name": "Launch Java App",
     "jdk.configurationSnippets.name": "Launch Java App",
     "jdk.configurationSnippets.label": "Java+: Launch Java Application",

--- a/vscode/package.nls.zh-cn.json
+++ b/vscode/package.nls.zh-cn.json
@@ -64,6 +64,7 @@
     "jdk.debugger.configuration.attach.listen.description": "监听要附加的被调试程序",
     "jdk.debugger.configuration.attach.timeout.description": "等待附加操作时的超时",
     "jdk.debugger.configuration.completion.warning.time.description": "When code completion takes longer than this specified time (in milliseconds), there will be a warning produced (-1 to disable)",
+    "jdk.configuration.java.completion.commit.chars": "Specifies the characters that trigger accepting a code completion suggestion. For example, to accept suggestions when typing a dot (.), set this to [\".\"]",
     "jdk.initialConfigurations.launchJavaApp.name": "启动 Java 应用程序",
     "jdk.configurationSnippets.name": "启动 Java 应用程序",
     "jdk.configurationSnippets.label": "Java+：启动 Java 应用程序",


### PR DESCRIPTION
- Currently `dot(".")` is provided by default as the code completion commit character alongwith `Tab` and `Enter`.
- According to VSCode guidelines and modern IDEs behaviour we should only provide `Tab` and `Enter` for accepting code completion suggestions. So, removed the default `.` character for accepting code completion.
- But, since some users might be already using `.` as their code completion character. Introduced a new configuration `jdk.java.completion.commit.chars` which accepts array of character for code completion commit.