### PR TITLE
Minor fix for telemetry backend and sanitisation of jdk versions

### DIFF
--- a/vscode/src/telemetry/telemetry.ts
+++ b/vscode/src/telemetry/telemetry.ts
@@ -26,7 +26,7 @@ export namespace Telemetry {
 
 	export const getIsTelemetryFeatureAvailable = (): boolean => {
 		const TELEMETRY_API = TelemetryConfiguration.getInstance()?.getApiConfig();
-		return TELEMETRY_API?.baseUrl != null && TELEMETRY_API?.baseUrl.trim().length > 0;
+		return TELEMETRY_API?.baseUrl != null && TELEMETRY_API?.baseUrl.trim().length > 0 && (TELEMETRY_API?.baseUrl.trim().startsWith("https://") || process.env['oracle_oracleJava_allow_httpTelemetryServer'] === "true");
 	}
 
 	export const initializeTelemetry = (contextInfo: ExtensionContextInfo): TelemetryManager => {

--- a/vscode/src/webviews/jdkDownloader/view.ts
+++ b/vscode/src/webviews/jdkDownloader/view.ts
@@ -196,7 +196,7 @@ export class JdkDownloaderView {
             if (isString(availableVersions)) {
                 const availableVersionsObj = JSON.parse(availableVersions);
                 if (availableVersionsObj?.items) {
-                    const jdkVersions = availableVersionsObj?.items?.map((version: any) => version.jdkDetails.jdkVersion);
+                    const jdkVersions = availableVersionsObj?.items?.map((version: any) => String(version.jdkDetails.jdkVersion).replace(/[^a-zA-Z0-9_.+-]/g,""));
                     LOGGER.log(`Fetched Oracle JDK versions: ${jdkVersions}`);
 
                     return jdkVersions;


### PR DESCRIPTION
- Added check for https telemetry backend url and added env var to override it.

- Filtered out non alphanumeric characters from jdk versions fetched dynamically.