### PR TITLE
Extension restart fix

### DIFF
--- a/vscode/l10n/bundle.l10n.en.json
+++ b/vscode/l10n/bundle.l10n.en.json
@@ -96,5 +96,6 @@
   "jdk.workspace.new.prompt": "Input the directory path where the new file will be generated",
   "jdk.extension.utils.error_message.failedHttpsRequest": "Failed to get {url} ({statusCode})",
   "jdk.extension.error_msg.notEnabled": "{SERVER_NAME} not enabled",
-  "jdk.telemetry.consent": "Allow anonymous telemetry data to be reported to Oracle? You may opt-out or in at any time from the Settings for jdk.telemetry.enabled."
+  "jdk.telemetry.consent": "Allow anonymous telemetry data to be reported to Oracle? You may opt-out or in at any time from the Settings for jdk.telemetry.enabled.",
+  "jdk.configChanged.updatedJdkPath": "JDK Home path changed , please reload window to restart extension."
 }

--- a/vscode/l10n/bundle.l10n.ja.json
+++ b/vscode/l10n/bundle.l10n.ja.json
@@ -96,5 +96,6 @@
   "jdk.workspace.new.prompt": "新しいファイルを生成するディレクトリのパスを入力してください",
   "jdk.extension.utils.error_message.failedHttpsRequest": "{url}の取得に失敗しました({statusCode})",
   "jdk.extension.error_msg.notEnabled": "{SERVER_NAME}が有効化されていません",
-  "jdk.telemetry.consent": "匿名テレメトリ・データをOracleにレポートすることを許可しますか。jdk.telemetry.enabledの設定からいつでもオプトアウトまたはオプトインできます。"
+  "jdk.telemetry.consent": "匿名テレメトリ・データをOracleにレポートすることを許可しますか。jdk.telemetry.enabledの設定からいつでもオプトアウトまたはオプトインできます。",
+    "jdk.configChanged.updatedJdkPath": "JDK Home path changed , please reload window to restart extension."
 }

--- a/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/vscode/l10n/bundle.l10n.zh-cn.json
@@ -96,5 +96,6 @@
   "jdk.workspace.new.prompt": "输入生成新文件的目录路径",
   "jdk.extension.utils.error_message.failedHttpsRequest": "无法获取 {url} ({statusCode})",
   "jdk.extension.error_msg.notEnabled": "{SERVER_NAME} 未启用",
-  "jdk.telemetry.consent": "是否允许向 Oracle 报告匿名遥测数据？您随时可以通过 jdk.telemetry.enabled 对应的设置选择退出或加入。"
+  "jdk.telemetry.consent": "是否允许向 Oracle 报告匿名遥测数据？您随时可以通过 jdk.telemetry.enabled 对应的设置选择退出或加入。",
+    "jdk.configChanged.updatedJdkPath": "JDK Home path changed , please reload window to restart extension."
 }

--- a/vscode/src/lsp/clientPromise.ts
+++ b/vscode/src/lsp/clientPromise.ts
@@ -13,12 +13,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { commands } from "vscode";
+import { commands,window  } from "vscode";
 import { LOGGER } from "../logger";
 import { NbProcessManager } from "./nbProcessManager";
 import { clientInit } from "./initializer";
 import { NbLanguageClient } from "./nbLanguageClient";
 import { globalState } from "../globalState";
+import { jdkDownloaderPrompt } from "../webviews/jdkDownloader/prompt";
+import { l10n } from "../localiser";
 
 export class ClientPromise {
     setClient!: [(c: NbLanguageClient) => void, (err: any) => void];
@@ -62,10 +64,15 @@ export class ClientPromise {
     public restartExtension = async (nbProcessManager: NbProcessManager | null, notifyKill: boolean) => {
         if (this.activationPending) {
             LOGGER.warn("Server activation requested repeatedly, ignoring...");
-            return;
         }
         if (!nbProcessManager) {
             LOGGER.error("Nbcode Process is null");
+            const reloadNow: string = l10n.value("jdk.downloader.message.reload");
+            const dialogBoxMessage = l10n.value("jdk.configChanged");
+            const selected = await window.showInformationMessage(dialogBoxMessage, reloadNow);
+            if (selected === reloadNow) {
+                await commands.executeCommand('workbench.action.reloadWindow');
+            }
             return;
         }
         try {

--- a/vscode/src/webviews/jdkDownloader/action.ts
+++ b/vscode/src/webviews/jdkDownloader/action.ts
@@ -121,13 +121,7 @@ export class JdkDownloaderAction {
             dialogBoxMessage = l10n.value("jdk.downloader.message.completedInstallingJdk");
         }
         LOGGER.log(`JDK installation completed successfully`);
-
-        const reloadNow: string = l10n.value("jdk.downloader.message.reload");
-        const selected = await window.showInformationMessage(dialogBoxMessage, reloadNow);
-        if (selected === reloadNow) {
-            await this.downloaderView.disposeView();
-            await commands.executeCommand('workbench.action.reloadWindow');
-        }
+        await window.showInformationMessage(dialogBoxMessage);
     }
 
     private jdkInstallationManager = async () => {


### PR DESCRIPTION
**Issue**
Post activating the extension one of the two cases happen

1)`JDK Found`
2)` No JDK Found`
In case of "No JDK Found" we enter a bad state where even if the user changes the jdk path to some valid path we cannot restart unless the user reloads .

In case initial JDK found but later user changes the path to an invalid jdk home then also we enter `No JDK Found`  state.
**Fix** 
Moved the reload window pop up from jdk downloader to configuration change listener(restartExtension) triggered  whenever any configuration is changed and extension is in bad state.
This gives user a prompt to reload window so that extension can come out of the bad state.