### PR TITLE
Fixed project clean and project compile commands in the command palette

### DIFF
--- a/vscode/src/commands/buildOperations.ts
+++ b/vscode/src/commands/buildOperations.ts
@@ -19,7 +19,7 @@ import { l10n } from "../localiser";
 import { extCommands, nbCommands } from "./commands";
 import { ICommand } from "./types";
 import { wrapCommandWithProgress, wrapProjectActionWithProgress } from "./utils";
-import { workspace } from "vscode";
+import { window, workspace } from "vscode";
 import * as fs from 'fs';
 
 const saveFilesInWorkspaceBeforeBuild = async (callbackFn: Function) => {
@@ -52,22 +52,31 @@ const cleanWorkspaceHandler = () => {
 }
 
 const compileProjectHandler = (args: any) => {
+    let commandArgs = args;
+    if (!commandArgs) {
+        commandArgs = window.activeTextEditor?.document.uri.toString();
+    }
+
     const compileProjectFunction = () =>
         wrapProjectActionWithProgress('build',
             undefined, l10n.value('jdk.extension.command.progress.compilingProject'),
             LOGGER.getOutputChannel(),
-            args
+            commandArgs
         );
 
     saveFilesInWorkspaceBeforeBuild(compileProjectFunction);
 }
 
 const cleanProjectHandler = (args: any) => {
+    let commandArgs = args;
+    if (!commandArgs) {
+        commandArgs = window.activeTextEditor?.document.uri.toString();
+    }
     const cleanProjectHandler = () => wrapProjectActionWithProgress('clean',
         undefined,
         l10n.value('jdk.extension.command.progress.cleaningProject'),
         LOGGER.getOutputChannel(),
-        args
+        commandArgs
     );
 
     saveFilesInWorkspaceBeforeBuild(cleanProjectHandler);


### PR DESCRIPTION
The editor was not passing the necessary context to the NetBeans LS when executing the `jdk.project.run.action` command. As a result, the LS lacked the information required to determine which project or file to `compile` or `clean`, leading to an undefined error.
It worked fine with the project view because it passes the project context to the Netbeans LS.

**Fix**
This PR ensures that the appropriate context from the editor is correctly passed to the NetBeans LS, allowing it to resolve the target of the action and execute it as expected.