### PR TITLE
Updated the JavaLangFeatures feature name extractor to work with JDK25+ EA

### DIFF
--- a/nbcode/telemetry/src/org/netbeans/modules/nbcode/java/lsp/server/telemetry/JavaLanguageFeaturesEmitter.java
+++ b/nbcode/telemetry/src/org/netbeans/modules/nbcode/java/lsp/server/telemetry/JavaLanguageFeaturesEmitter.java
@@ -74,9 +74,9 @@ class JavaLanguageFeaturesEmitter implements Runnable {
             task = (JavacTask) ToolProvider.getSystemJavaCompiler().getTask(null, null, dl, List.of("--source", "8", "--source-path", sourceInfo.getSourcesPath()), null, List.of(sourceInfo.source));
             task.analyze();
         } catch (IOException e) {
-            LOG.log(Level.FINE, "IO error while scanning Java Language features: {0}", e);
+            LOG.log(Level.FINE, "IO error while scanning Java Language features: {0}", (Object) e);
         } catch (IllegalArgumentException e) {
-            LOG.log(Level.CONFIG, "Invalid parsing parameters for scanning Java Language features: {0}", e);
+            LOG.log(Level.CONFIG, "Invalid parsing parameters for scanning Java Language features: {0}", (Object) e);
         } catch (RuntimeException ignored) {
         }
         return featuresUsed;


### PR DESCRIPTION
Updated the code to obtain the parent diagnostics keys for feature-related errors/warnings to be agnostic to movement across different diagnostic types in different JDKs.
For example, Warning -> LinterWarning