### PR TITLE
Constructor init of java.lsp.server JavaPlatformProvider override

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,6 +64,7 @@
             patches/8460-draft.diff
             patches/8470.diff
             patches/8484.diff
+            patches/8745-draft.diff
             patches/disable-error-notification.diff
             patches/mvn-sh.diff
             patches/project-marker-jdk.diff

--- a/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspJavaPlatformProviderOverride.java
+++ b/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspJavaPlatformProviderOverride.java
@@ -28,4 +28,8 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = JavaPlatformProvider.class, position = 10_000)
 public class LspJavaPlatformProviderOverride extends AbstractJavaPlatformProviderOverride {
+
+    public LspJavaPlatformProviderOverride() {
+        super(System.getProperty("netbeans.lsp.java.platform.override", null)); //NOI18N
+    }
 }

--- a/patches/8745-draft.diff
+++ b/patches/8745-draft.diff
@@ -1,0 +1,19 @@
+diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
+index df668954dd..054f85d0e5 100644
+--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
++++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
+@@ -39,6 +39,14 @@ public abstract class AbstractJavaPlatformProviderOverride implements JavaPlatfo
+     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+     private FileObject defaultPlatformOverride;
+ 
++    public AbstractJavaPlatformProviderOverride() {
++        this(null);
++    }
++
++    protected AbstractJavaPlatformProviderOverride(String defaultPlatformOverride) {
++        this.defaultPlatformOverride = defaultPlatformOverride == null ? null : FileUtil.toFileObject(new File(defaultPlatformOverride));
++    }
++
+     @Override
+     @SuppressWarnings("ReturnOfCollectionOrArrayField")
+     public JavaPlatform[] getInstalledPlatforms() {

--- a/vscode/src/configurations/handlers.ts
+++ b/vscode/src/configurations/handlers.ts
@@ -55,6 +55,10 @@ export const jdkHomeValueHandler = (): string | null => {
         null;
 }
 
+export const projectJdkHomeValueHandler = (): string | null => {
+    return getConfigurationValue(configKeys.projectJdkHome, null);
+}
+
 export const projectSearchRootsValueHandler = (): string => {
     let projectSearchRoots: string = '';
     const isProjectFolderSearchLimited: boolean = !getConfigurationValue(configKeys.disableProjSearchLimit, false);

--- a/vscode/src/lsp/launchOptions.ts
+++ b/vscode/src/lsp/launchOptions.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 import { builtInConfigKeys, configKeys } from "../configurations/configuration"
-import { isDarkColorThemeHandler, isNetbeansVerboseEnabled, jdkHomeValueHandler, lspServerVmOptionsHandler, projectSearchRootsValueHandler, userdirHandler } from "../configurations/handlers";
+import { isDarkColorThemeHandler, isNetbeansVerboseEnabled, jdkHomeValueHandler, projectJdkHomeValueHandler, lspServerVmOptionsHandler, projectSearchRootsValueHandler, userdirHandler } from "../configurations/handlers";
 import { l10n } from "../localiser";
 import { isString } from "../utils";
 import { userDefinedLaunchOptionsType } from "./types"
@@ -25,6 +25,10 @@ export const getUserConfigLaunchOptionsDefaults = (): userDefinedLaunchOptionsTy
             value: jdkHomeValueHandler(),
             optionToPass: ['--jdkhome']
         },
+        [configKeys.projectJdkHome]: {
+            value: projectJdkHomeValueHandler(),
+            optionToPass: '-J-Dnetbeans.lsp.java.platform.override='
+        }, 
         [configKeys.userdir]: {
             value: userdirHandler(),
             optionToPass: ['--userdir']


### PR DESCRIPTION
1. Brings NetBeans PR apache/netbeans#8745 as a patch

2. Allowed `LspJavaPlatformProviderOverride` to initialize the override based on the value set for the option "netbeans.lsp.java.platform.override" passed as a JVM system property.

3. Utilised platform override system property in Java VSCode extension
    1. From the Java VSCode extension, passed the value of "`jdk.project.jdkhome`" configuration to the NBLS via the JVM system property flag "`netbeans.lsp.java.platform.override`".
    2. This additionally allows the `LspJavaPlatformProviderOverride` to initialize the `JavaPlatform` override during construction, avoiding any caching of the default platform prior to the configuration being read via LSP.

Thanks to @lahodaj for the idea of this fix.