### PR TITLE
Fixing outline view of compact source files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,6 +57,7 @@
             patches/8745-draft.diff
             patches/8770.diff
             patches/8827.diff
+            patches/8856-draft.diff
             patches/disable-error-notification.diff
             patches/mvn-sh.diff
             patches/project-marker-jdk.diff

--- a/patches/8856-draft.diff
+++ b/patches/8856-draft.diff
@@ -1,0 +1,15 @@
+diff --git a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+index f561cb51c8..81000c3ed9 100644
+--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
++++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+@@ -573,6 +573,10 @@ public final class ElementOpen {
+         int[] span = null;
+         switch(forTree.getKind()) {
+             case CLASS:
++                if ((int) target[1] >= 0 && (int) target[2] == -1) {
++                // Compact Source file (JEP 512)  issue implicit class end position not found in code 
++                    target[2] = (int) info.getTrees().getSourcePositions().getEndPosition(cu, cu);
++                }
+             case INTERFACE:
+             case ENUM:
+             case ANNOTATION_TYPE:


### PR DESCRIPTION
- Compact source files in java don't have top level class.
- Methods and fields are allowed as top level elements .
- Due to the erroneous computation of the end position for the hidden final class created to scaffold the compact source file methods and fields the outline view was not showing the document symbols for these files.
- This patch does a simple fix to ensure that the LSP backend sends ranges where end position for a document symbol if not found is taken same as the start position .
- Final fix could perhaps correct the end position computation directly .

