### PR TITLE
Updating OpenJDK 25 URL to that for 25.0.1

### DIFF
--- a/vscode/src/constants.ts
+++ b/vscode/src/constants.ts
@@ -35,7 +35,7 @@ export namespace jdkDownloaderConstants {
   export const ORACLE_JDK_FALLBACK_VESIONS = ['25', '21'];
 
   export const OPEN_JDK_VERSION_DOWNLOAD_LINKS: { [key: string]: string } = {
-    "25": "https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25"
+    "25": "https://download.java.net/java/GA/jdk25.0.1/2fbf10d8c78e40bd87641c434705079d/8/GPL/openjdk-25.0.1"
   };  
 }
 export const NODE_WINDOWS_LABEL = "Windows_NT";


### PR DESCRIPTION
Updated base URL for openjdk 25 to point to 25.0.1