### PR TITLE
Updated LSP new from template command input validation rules

### DIFF
--- a/patches/7893-draft.diff
+++ b/patches/7893-draft.diff
@@ -1,5 +1,5 @@
 diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
-index 891bfa328d..ed80b903a5 100644
+index 891bfa328d..91172fda4b 100644
 --- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
 +++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
 @@ -27,6 +27,7 @@ import java.net.MalformedURLException;
@@ -103,7 +103,7 @@ index 891bfa328d..ed80b903a5 100644
          });
      }
  
-@@ -229,9 +253,21 @@ final class LspTemplateUI {
+@@ -229,9 +253,23 @@ final class LspTemplateUI {
          FileObject template = desc.getTemplate();
          Object handler = template.getAttribute(FileBuilder.ATTR_TEMPLATE_HANDLER);
          if (handler == null) {
@@ -114,8 +114,10 @@ index 891bfa328d..ed80b903a5 100644
 +
 +                @Override
 +                public CompletionStage<String> apply(String name) {
-+                    if (!SourceVersion.isName(name)) {
-+                        client.showMessage(new MessageParams(MessageType.Error, Bundle.ERR_InvalidObjectName(name)));
++                    if (!name.equals("package-info") && !name.equals("module-info")
++                        && (SourceVersion.isKeyword(name) || !SourceVersion.isIdentifier(name)))
++                    {
++                        client.showMessage(new MessageParams(MessageType.Error,Bundle.ERR_InvalidObjectName(name)));
 +                        return client.showInputBox(new ShowInputBoxParams(Bundle.CTL_TemplateUI_SelectName(), desc.getProposedName())).thenCompose(this);
 +                    }
 +                    return CompletableFuture.completedFuture(name);
@@ -128,7 +130,7 @@ index 891bfa328d..ed80b903a5 100644
          }
          return CompletableFuture.completedFuture(builder);
      }
-@@ -242,7 +278,7 @@ final class LspTemplateUI {
+@@ -242,7 +280,7 @@ final class LspTemplateUI {
              suggestion = Utilities.toFile(new URI(folders.get(0).getUri())).getParent();
          } catch (URISyntaxException ex) {
          }


### PR DESCRIPTION
1. Allowed 'module-info' and 'package-info' as special cases.
2. Allowed only simple names which are not keywords hence not allowing names which have dots.