### PR TITLE
Handle user dismissal of input box in notebook instead of closing input stream

### DIFF
--- a/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/CustomInputStreamTest.java
+++ b/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/CustomInputStreamTest.java
@@ -1,10 +1,11 @@
 package org.netbeans.modules.nbcode.java.notebook;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,10 +34,10 @@ public class CustomInputStreamTest {
     @Test
     public void testReadNoClient() throws IOException {
         inputStream = new CustomInputStream(null);
-        assertEquals(-1, inputStream.read());
+        Assert.assertThrows(EOFException.class, ()-> inputStream.read());            
 
         byte[] buffer = new byte[10];
-        assertEquals(-1, inputStream.read(buffer, 0, 10));
+        Assert.assertThrows(EOFException.class, ()-> inputStream.read(buffer, 0, 10));
     }
 
     @Test


### PR DESCRIPTION
JShell automatically closes the input stream when `-1` is returned via `CustomInputStream`, with no mechanism to reopen or reset it.
This change replaces `-1` returns with `EOFException` to safely signal user dismissal while keeping the stream open.