### PR TITLE
Allow the extension NBLS to launch on Windows arm64 with x64 JDK

### DIFF
--- a/vscode/src/lsp/utils.ts
+++ b/vscode/src/lsp/utils.ts
@@ -44,7 +44,7 @@ export const enableDisableModules = (
 
 export const findNbcode = (extensionPath: string): string => {
     let nbcode = os.platform() === 'win32' ?
-        os.arch() === 'x64' ? 'nbcode64.exe' : 'nbcode.exe'
+        os.arch() === 'x64' || os.arch() === 'arm64' ? 'nbcode64.exe' : 'nbcode.exe'
         : 'nbcode.sh';
     let nbcodePath = path.join(extensionPath, "nbcode", "bin", nbcode);
 


### PR DESCRIPTION
The NBLS launch on Windows arm64 is fixed to use the x64 version of nbcode exe launcher.
- This will allow the use of the extension on this platform with `jdk.jdkhome` set to an x64 JDK.
- If the user programs need to be run on an arm64 JDK, the `jdk.project.jdkhome` can be set to the arm64 JDK.
- Note: Currently there is no arm64 windows build of the nbcode launcher.