### PR TITLE
Allow project context button in any notebook 

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -832,12 +832,12 @@
 				{
 					"command": "jdk.notebook.change.project",
 					"group": "navigation@1",
-					"when": "nbJdkReady && resourceExtname == .ijnb"
+					"when": "nbJdkReady"
 				},
 				{
 					"command": "jdk.notebook.restart.kernel",
 					"group": "navigation/execute@5",
-					"when": "nbJdkReady && resourceExtname == .ijnb"
+					"when": "nbJdkReady"
 				}
 			]
 		},


### PR DESCRIPTION
Fixes the issue of `Project Context` button missing in java notebook with `ipynb` extension