### PR TITLE
VM Options support for Notebooks and fixed Enable Preview Option

### DIFF
--- a/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookSessionManager.java
+++ b/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2025-2026, Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,9 @@ public class NotebookSessionManager {
                 .err(streamsHandler.getPrintErrStream())
                 .in(streamsHandler.getInputStream());
 
+        LOG.log(Level.FINE, "Initializing Notebook kernel for {0}", notebookUri);
+        LOG.log(Level.FINE, "Compiler options being passed: {0}", compilerOptions);
+        LOG.log(Level.FINE, "VM Options being passed to notebook kernel: {0}", remoteOptions);
         if (!compilerOptions.isEmpty()) {
             builder.compilerOptions(compilerOptions.toArray(new String[0]))
                     .remoteVMOptions(remoteOptions.toArray(new String[0]));
@@ -226,6 +229,10 @@ public class NotebookSessionManager {
         if (enablePreview) {
             remoteOptions.add(ENABLE_PREVIEW);
         }
+        
+        List<String> extraVmOptions = NotebookConfigs.getInstance().getNotebookVmOptions();
+        remoteOptions.addAll(extraVmOptions);
+        
         return remoteOptions;
     }
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -300,6 +300,11 @@
 					"default": {},
 					"description": "%jdk.notebook.projects.mapping.description%"
 				},
+				"jdk.notebook.vmOptions": {
+					"type": "array",
+					"default": [],
+					"description": "%jdk.notebook.vmOptions.description%"
+				},
 				"jdk.telemetry.enabled": {
 					"type": "boolean",
 					"description": "%jdk.configuration.telemetry.enabled.description%",

--- a/vscode/package.nls.ja.json
+++ b/vscode/package.nls.ja.json
@@ -78,6 +78,7 @@
     "jdk.notebook.implicitImports.description": "Javaノートブックで暗黙的にインポートする要素のリスト。空のときのデフォルトはjava.util、java.ioおよびjava.mathパッケージのスター・インポート。",
     "jdk.notebook.implicitImports.markdownDescription": "Javaノートブックで暗黙的にインポートする要素のリスト。空のときのデフォルトは`java.util`、`java.io`および`java.math`パッケージのスター・インポート。",
     "jdk.notebook.projects.mapping.description": "Javaノートブック・パスの、コンテキストを提供するプロジェクトのパスへのマッピング。",
+    "jdk.notebook.vmOptions.description": "The specific Java VM options for use in Java notebooks. These options are added in addition to the project configuration, including class-path, module-path, preview features, and added modules.",
     "jdk.configuration.java.completion.commit.chars": "コード補完の提案の受入れをトリガーする文字を指定します。たとえば、ピリオド(.)を入力したときに提案を受け入れるには、これを[\".\"]に設定します",
     "jdk.initialConfigurations.launchJavaApp.name": "Javaアプリケーションの起動",
     "jdk.configurationSnippets.name": "Javaアプリケーションの起動",

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -78,6 +78,7 @@
     "jdk.notebook.implicitImports.description": "List of elements to implicitly import in Java notebooks. Defaults to star-imports of java.util, java.io and java.math packages, when empty.",
     "jdk.notebook.implicitImports.markdownDescription": "List of elements to implicitly import in Java notebooks. Defaults to star-imports of `java.util`, `java.io` and `java.math` packages, when empty.",
     "jdk.notebook.projects.mapping.description": "Mapping of Java notebook paths to the path of the project that provides it context.",
+    "jdk.notebook.vmOptions.description": "The specific Java VM options for use in Java notebooks. These options are added in addition to the project configuration, including class-path, module-path, preview features, and added modules.",
     "jdk.configuration.java.completion.commit.chars": "Specifies the characters that trigger accepting a code completion suggestion. For example, to accept suggestions when typing a dot (.), set this to [\".\"]",
     "jdk.initialConfigurations.launchJavaApp.name": "Launch Java App",
     "jdk.configurationSnippets.name": "Launch Java App",

--- a/vscode/package.nls.zh-cn.json
+++ b/vscode/package.nls.zh-cn.json
@@ -78,6 +78,7 @@
     "jdk.notebook.implicitImports.description": "要在 Java 记事本中隐式导入的元素列表。为空时，默认为 java.util、java.io 和 java.math 程序包的星型导入。",
     "jdk.notebook.implicitImports.markdownDescription": "要在 Java 记事本中隐式导入的元素列表。为空时，默认为 `java.util`、`java.io` 和 `java.math` 程序包的星型导入。",
     "jdk.notebook.projects.mapping.description": "将 Java 记事本路径映射到提供记事本上下文的项目的路径。",
+    "jdk.notebook.vmOptions.description": "The specific Java VM options for use in Java notebooks. These options are added in addition to the project configuration, including class-path, module-path, preview features, and added modules.",
     "jdk.configuration.java.completion.commit.chars": "指定用于触发接受代码补全建议的字符。例如，要在键入点 (.) 时接受建议，请将该字符设为 [\".\"]",
     "jdk.initialConfigurations.launchJavaApp.name": "启动 Java 应用程序",
     "jdk.configurationSnippets.name": "启动 Java 应用程序",

--- a/vscode/src/configurations/configuration.ts
+++ b/vscode/src/configurations/configuration.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2023-2024, Oracle and/or its affiliates.
+  Copyright (c) 2023-2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,8 +36,9 @@ export const configKeys = {
     notebookAddModules: "notebook.addmodules",
     notebookEnablePreview: "notebook.enablePreview",
     notebookImplicitImports: "notebook.implicitImports",
-    telemetryEnabled: 'telemetry.enabled',
-    notebookProjectMapping: "notebook.projects.mapping"
+    notebookProjectMapping: "notebook.projects.mapping",
+    notebookVmOptions: "notebook.vmOptions",
+    telemetryEnabled: 'telemetry.enabled'
 };
 
 export const builtInConfigKeys = {
@@ -56,6 +57,7 @@ export const userConfigsListened: string[] = [
     appendPrefixToCommand(configKeys.notebookEnablePreview),
     appendPrefixToCommand(configKeys.notebookImplicitImports),
     appendPrefixToCommand(configKeys.notebookProjectMapping),
+    appendPrefixToCommand(configKeys.notebookVmOptions),
     builtInConfigKeys.vscodeTheme,
 ];
 


### PR DESCRIPTION
Added VM Options config for notebooks, fixed enable preview failing with EA versions bug and added logger for knowing with which options the kernel is being launched.

Closes #539 