### PR TITLE
Fixed ordering of commands in the explorer window

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -763,12 +763,12 @@
 				{
 					"command": "jdk.workspace.new",
 					"when": "nbJdkReady && explorerResourceIsFolder",
-					"group": "navigation@3"
+					"group": "navigation@7"
 				},
 				{
 					"command": "jdk.notebook.new",
 					"when": "nbJdkReady && explorerResourceIsFolder",
-					"group": "navigation@3"
+					"group": "navigation@8"
 				},
 				{
 					"command": "jdk.open.test",


### PR DESCRIPTION
We had earlier set our commands to start from position `3`, but it seems that VS Code’s native commands use the ordering `4` and `6`. So, for our commands to come after those, we need to start our ordering from `7`. This has now been fixed.

Updated Explorer window context:
<img width="298" height="480" alt="Screenshot 2026-04-21 at 3 06 45 PM (2)" src="https://github.com/user-attachments/assets/c98bc30a-041f-4698-81f6-4c87aad9fb3c" />

closes #564 
