### PR TITLE
Relaxed version check on the notebook format

### DIFF
--- a/vscode/l10n/bundle.l10n.en.json
+++ b/vscode/l10n/bundle.l10n.en.json
@@ -134,6 +134,7 @@
   "jdk.notebook.serializer.error_msg": "Failed to serialize notebook: {errorMessage}",
   "jdk.notebook.cell.serializer.error_msg": "Failed to serialize one or more cells",
   "jdk.notebook.validation.failed.error_msg": "Notebook JSON validation failed",
+  "jdk.notebook.validation.notebook_version.failed.error_msg": "Notebook version is not supported. Please upgrade to version {majorVersion}.{minorVersion} or later.",
   "jdk.notebook.mime_type.not.found.cell.output": "Mime Type: {mimeType}, Content Length: {contentLength}",
   "jdk.notebook.cell.language.not.found": "Doesn't support {languageId} execution"
 }

--- a/vscode/l10n/bundle.l10n.ja.json
+++ b/vscode/l10n/bundle.l10n.ja.json
@@ -134,6 +134,7 @@
   "jdk.notebook.serializer.error_msg": "ノートブックのシリアライズに失敗しました: {errorMessage}",
   "jdk.notebook.cell.serializer.error_msg": "1つ以上のセルのシリアライズに失敗しました",
   "jdk.notebook.validation.failed.error_msg": "ノートブックJSON検証に失敗しました",
+  "jdk.notebook.validation.notebook_version.failed.error_msg": "Notebook version is not supported. Please upgrade to version {majorVersion}.{minorVersion} or later.",
   "jdk.notebook.mime_type.not.found.cell.output": "MIMEタイプ: {mimeType}、コンテンツの長さ: {contentLength}",
   "jdk.notebook.cell.language.not.found": "{languageId}の実行はサポートされていません"
 }

--- a/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/vscode/l10n/bundle.l10n.zh-cn.json
@@ -133,7 +133,8 @@
   "jdk.notebook.cell.missing.error_msg": "缺少字段：{fieldName}",
   "jdk.notebook.serializer.error_msg": "无法串行化记事本：{errorMessage}",
   "jdk.notebook.cell.serializer.error_msg": "无法串行化一个或多个单元格",
-  "jdk.notebook.validation.failed.error_msg": "记事本 JSON 验证失败",
+  "jdk.notebook.validation.failed.error_msg": "记事本 JSON 验证失败",  
+  "jdk.notebook.validation.notebook_version.failed.error_msg": "Notebook version is not supported. Please upgrade to version {majorVersion}.{minorVersion} or later.",
   "jdk.notebook.mime_type.not.found.cell.output": "Mime 类型：{mimeType}，内容长度：{contentLength}",
   "jdk.notebook.cell.language.not.found": "不支持 {languageId} 执行"
 }

--- a/vscode/src/notebooks/nbformat.v4.d7.schema.json
+++ b/vscode/src/notebooks/nbformat.v4.d7.schema.json
@@ -94,15 +94,14 @@
       }
     },
     "nbformat_minor": {
-      "description": "Notebook format (minor number). Incremented for backward compatible changes to the notebook format.",
+      "description": "Notebook format (minor number). Incremented for backward compatible changes to the notebook format. Note: the minimum version constraint has been relaxed from the original spec (5 → 0) to allow validation of newer major versions beyond those explicitly defined.",
       "type": "integer",
-      "minimum": 5
+      "minimum": 0
     },
     "nbformat": {
       "description": "Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.",
       "type": "integer",
-      "minimum": 4,
-      "maximum": 4
+      "minimum": 4
     },
     "cells": {
       "description": "Array of cells of the current notebook.",

--- a/vscode/src/notebooks/notebook.ts
+++ b/vscode/src/notebooks/notebook.ts
@@ -91,6 +91,19 @@ export class Notebook {
             LOGGER.error(`Notebook JSON validation failed:\n${errors}`);
             throw new Error(l10n.value("jdk.notebook.validation.failed.error_msg"));
         }
+
+        if (!Notebook.isSupportedNotebookVersion(notebook)) {
+            LOGGER.error(`Notebook version validation failed: unsupported notebook version ${notebook.nbformat}.${notebook.nbformat_minor}.`);
+            throw new Error(l10n.value("jdk.notebook.validation.notebook_version.failed.error_msg",
+                { majorVersion: NotebookVersionInfo.NBFORMAT, minorVersion: NotebookVersionInfo.NBFORMAT_MINOR }));
+        }
+
         LOGGER.debug("Notebook successfully validated.");
+    }
+
+    private static isSupportedNotebookVersion(notebook: INotebook): boolean {
+        return notebook.nbformat > NotebookVersionInfo.NBFORMAT ||
+            (notebook.nbformat === NotebookVersionInfo.NBFORMAT &&
+                notebook.nbformat_minor >= NotebookVersionInfo.NBFORMAT_MINOR);
     }
 }

--- a/vscode/src/test/unit/notebooks/notebook.unit.test.ts
+++ b/vscode/src/test/unit/notebooks/notebook.unit.test.ts
@@ -1,0 +1,82 @@
+/*
+  Copyright (c) 2026, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { expect } from 'chai';
+import { describe, it, afterEach } from 'mocha';
+import * as sinon from 'sinon';
+import { Notebook } from '../../../notebooks/notebook';
+import { INotebook } from '../../../notebooks/types';
+
+describe('Notebook assertValidNotebookJson tests', () => {
+  const createNotebook = (): INotebook => ({
+    nbformat: 4,
+    nbformat_minor: 5,
+    metadata: {
+      language_info: {
+        name: 'java',
+      },
+    },
+    cells: [
+      {
+        id: 'cell-1',
+        cell_type: 'markdown',
+        metadata: {},
+        source: 'Hello notebook',
+      },
+    ],
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('accepts notebooks that declare a newer nbformat version', () => {
+    const notebook = {
+      ...createNotebook(),
+      nbformat: 5,
+      nbformat_minor: 1,
+    };
+
+    expect(() => Notebook.assertValidNotebookJson(notebook)).not.to.throw();
+  });
+
+  it('rejects v4 notebooks older than the supported minor version baseline', () => {
+    const notebook = {
+      ...createNotebook(),
+      nbformat: 4,
+      nbformat_minor: 4,
+    };
+
+    expect(() => Notebook.assertValidNotebookJson(notebook)).to.throw('jdk.notebook.validation.notebook_version.failed.error_msg');
+  });
+
+  it('still rejects invalid notebook structure for newer nbformat versions', () => {
+    const notebook = {
+      ...createNotebook(),
+      nbformat: 5,
+      nbformat_minor: 1,
+      cells: [
+        {
+          cell_type: 'markdown',
+          metadata: {},
+          source: 'Hello notebook',
+        },
+      ],
+    } as INotebook;
+
+    expect(() => Notebook.assertValidNotebookJson(notebook)).to.throw('jdk.notebook.validation.failed.error_msg');
+  });
+});


### PR DESCRIPTION
Currently, there is a version validation check on the notebook version: it must be greater than or equal to 4.5, and the major version must be 4.

This requirement is now being relaxed to allow versions greater than or equal to 4.5 with a major version above 4 as well. This change ensures that users with newer notebook versions can still use our extension, as long as their notebooks adhere to the 4.5 schema and do not introduce any breaking changes.