### PR TITLE
Temporarily hide the jdk.advanced.disable.nbjavac setting

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -386,6 +386,7 @@
 					"jdk.advanced.disable.nbjavac": {
 						"type": "boolean",
 						"default": false,
+						"deprecationMessage": "This setting is temporarily hidden since it is currently unsupported for JDK 26 and early-access versions of JDK 27 and higher.",
 						"description": "%jdk.configuration.disableNbJavac.description%"
 					},
 					"jdk.advanced.disable.projectSearchLimit": {


### PR DESCRIPTION
Hide this setting using a `deprecationMessage`, since it is currently unsupported for JDK 26 and early-access versions of JDK 27 and higher.

Refer known-issue described in [README](https://github.com/oracle/javavscode/blob/main/README.md#Known-Issues)