### PR TITLE
Fixed the new ID in the deprecationMessage for jdk.format.settingsPath

### DIFF
--- a/vscode/package.nls.ja.json
+++ b/vscode/package.nls.ja.json
@@ -52,7 +52,7 @@
     "jdk.configuration.testEditor.description": "エディタで実行/デバッグ・テストを有効にします",
     "jdk.configuration.javadoc.timeout.description": "コード補完でのJavadocのロードのタイムアウト(ミリ秒)(無制限は-1)",
     "jdk.configuration.formatterSettings.description": "エクスポート済のフォーマッタ設定を含むファイルへのパス",
-    "jdk.configuration.formatterSettings.deprecationMessage": "この設定は非推奨になる予定です。jdk.format.settingsに移行してください",
+    "jdk.configuration.formatterSettings.deprecationMessage": "この設定は非推奨になる予定です。jdk.format.optionsに移行してください",
     "jdk.configuration.formatOptions.description" : "書式設定オプションのコンテナ。有効なキーおよび値については、次のドキュメントを参照してください: https://github.com/oracle/javavscode/wiki/Java-formatting-preferences",
     "jdk.configuration.formatOptions.markdownDescription" : "書式設定オプションのコンテナ。有効なキーおよび値については、次のドキュメントを参照してください: [Java-formatting-preferences](https://github.com/oracle/javavscode/wiki/Java-formatting-preferences)",
     "jdk.configuration.hints.preferences.description": "エクスポート済のヒント・プリファレンスを含むファイルへのパス",

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -52,7 +52,7 @@
     "jdk.configuration.testEditor.description": "Enable Run/Debug test in editor",
     "jdk.configuration.javadoc.timeout.description": "Timeout (in milliseconds) for loading Javadoc in code completion (-1 for unlimited)",
     "jdk.configuration.formatterSettings.description": "Path to the file containing exported formatter settings",
-    "jdk.configuration.formatterSettings.deprecationMessage": "This setting is scheduled for deprecation. Please migrate to jdk.format.settings",
+    "jdk.configuration.formatterSettings.deprecationMessage": "This setting is scheduled for deprecation. Please migrate to jdk.format.options",
     "jdk.configuration.formatOptions.description" : "A container for formatting options. Refer to the following documentation for valid keys and values: https://github.com/oracle/javavscode/wiki/Java-formatting-preferences",
     "jdk.configuration.formatOptions.markdownDescription" : "A container for formatting options. Refer to the following documentation for valid keys and values: [Java-formatting-preferences](https://github.com/oracle/javavscode/wiki/Java-formatting-preferences)",
     "jdk.configuration.hints.preferences.description": "Path to the file containing exported hints preferences",

--- a/vscode/package.nls.zh-cn.json
+++ b/vscode/package.nls.zh-cn.json
@@ -52,7 +52,7 @@
     "jdk.configuration.testEditor.description": "在编辑器中启用运行/调试测试",
     "jdk.configuration.javadoc.timeout.description": "在代码完成时加载 Javadoc 的超时（毫秒）（-1 表示无限制）",
     "jdk.configuration.formatterSettings.description": "包含导出的格式化工具设置的文件的路径",
-    "jdk.configuration.formatterSettings.deprecationMessage": "此设置已计划弃用。请迁移到 jdk.format.settings",
+    "jdk.configuration.formatterSettings.deprecationMessage": "此设置已计划弃用。请迁移到 jdk.format.options",
     "jdk.configuration.formatOptions.description" : "用于格式设置选项的容器。有关有效的键和值，请参阅以下文档：https://github.com/oracle/javavscode/wiki/Java-formatting-preferences",
     "jdk.configuration.formatOptions.markdownDescription" : "用于格式设置选项的容器。有关有效的键和值，请参阅以下文档：[Java-formatting-preferences](https://github.com/oracle/javavscode/wiki/Java-formatting-preferences)",
     "jdk.configuration.hints.preferences.description": "包含导出的提示首选项的文件的路径",


### PR DESCRIPTION
New setting ID typo fix: `jdk.format.settings` -> `jdk.format.options` in the deprecation message of `jdk.format.settingsPath`