### PR TITLE
Fixed jdkHome config value handler fallback to env vars

### DIFF
--- a/vscode/src/configurations/handlers.ts
+++ b/vscode/src/configurations/handlers.ts
@@ -57,10 +57,11 @@ export const inspectConfiguration = (config: string) => {
 }
 
 export const jdkHomeValueHandler = async (): Promise<string | null> => {
-    return getConfigurationValueWithVariablesSubstituted(configKeys.jdkHome) ||
-        process.env.JDK_HOME ||
-        process.env.JAVA_HOME ||
-        null;
+    return getConfigurationValueWithVariablesSubstituted<string | null>(configKeys.jdkHome)
+        .then(resolvedValue => resolvedValue ||
+            process.env.JDK_HOME ||
+            process.env.JAVA_HOME ||
+            null);
 }
 
 export const projectJdkHomeValueHandler = async (): Promise<string | null> => {


### PR DESCRIPTION
Fixed `handler.ts:jdkHomeValueHandler()` to have the promise return the fallback env vars `JDK_HOME` or `JAVA_HOME` when no config value is defined.
- The config getter returns the default value i.e. `null`, in such a case.
- Thus, the `defaultValue` parameter cannot be used, since the vscode config getter returns the default value defined in package.json, causing the value to not be `undefined`.
- So, a `then()` clause on the promise is needed to check for `null` or `undefined` value, and fallback to the env vars, if so.